### PR TITLE
docs: add MAX v3 implementation plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This repository is a Python package for the MaiCoin MAX API. Core package code lives under `maicoin/`:
+
+- `maicoin/ws/` contains WebSocket models, requests, responses, subscriptions, and stream helpers.
+- `maicoin/v2/` contains HTTP API-related modules.
+- `tests/` mirrors package areas, with current coverage focused on `tests/ws/`.
+- `example.py` demonstrates loading MAX credentials from `.env` and running the package locally.
+
+## Build, Test, and Development Commands
+
+Use Poetry for dependency management:
+
+```shell
+poetry install
+poetry run pytest
+poetry run pytest --cov=maicoin
+poetry run ruff check .
+```
+
+For a quick local package check, run:
+
+```shell
+pip install .
+python example.py
+```
+
+## Coding Style & Naming Conventions
+
+Target Python 3.10+. Ruff is the primary linter; keep lines at or below 120 characters. Ruff enforces pycodestyle, pyflakes, isort, pep8-naming, pyupgrade, flake8-bugbear, and flake8-comprehensions rules. Imports should be sorted with one import per line. Keep public models and request/response classes named clearly after MAX API concepts, matching existing files such as `ticker.py`, `order.py`, and `subscription.py`.
+
+## Testing Guidelines
+
+Use pytest. Place tests under `tests/` using `test_*.py` filenames and mirror the package path when adding new modules. Prefer deterministic unit tests for serialization, parsing, validation, and request construction. Run `poetry run pytest` before submitting changes; use `poetry run pytest --cov=maicoin` when changing core API behavior.
+
+## API Reference Links
+
+When implementing or reviewing API behavior, consult the official MAX documentation first:
+
+- HTTP API v3: https://max-api.maicoin.com/doc/v3.html
+- WebSocket API: https://maicoin.github.io/max-websocket-docs/
+
+Keep naming, payload fields, channel names, and authentication behavior aligned with those references.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses short imperative or dependency-update messages, often from Dependabot. Keep commits focused and descriptive, for example `Add websocket ticker parsing tests` or `Bump actions/checkout from 4 to 5`. Pull requests should include a summary, test results, and links to related issues or API documentation when behavior changes.
+
+## Security & Configuration Tips
+
+Do not commit `.env` files, API keys, or secrets. Use `MAX_API_KEY` and `MAX_API_SECRET` only through local environment variables or ignored local configuration.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,120 @@
+# PLAN.md
+
+## Goal
+
+Add the missing MAX REST API v3 support while preserving the existing WebSocket API behavior. The current codebase is centered on `maicoin/ws/`; REST support only contains the single `GET /api/v2/k` K-line endpoint in `maicoin/v2/kline.py`. The README also still marks the HTTP API as unfinished, so the next implementation target should be a new `maicoin/v3/` package.
+
+Official references:
+
+- REST API v3: https://max-api.maicoin.com/doc/v3.html
+- WebSocket API: https://maicoin.github.io/max-websocket-docs/
+
+## Current State
+
+### Implemented
+
+- WebSocket public channels: book, trade, ticker, kline, and market_status.
+- Basic WebSocket private response models for order, trade, and account events.
+- WebSocket auth, subscribe, unsubscribe request models, and stream helper.
+- REST v2: only `GET /api/v2/k` K-line lookup.
+- Tests focused on WebSocket request, response, and subscription model validation.
+
+### Missing
+
+- REST API v3 package and public/private client.
+- REST API v3 authentication with `X-MAX-ACCESSKEY`, `X-MAX-PAYLOAD`, and `X-MAX-SIGNATURE`.
+- REST API v3 public endpoints: markets, currencies, timestamp, k, depth, trades, tickers, ticker, index prices, and m-wallet public rates/limits.
+- REST API v3 private endpoints: orders, trades, accounts, withdrawals, deposits, fund transactions, convert, and m-wallet loan/repayment/liquidation/interest/transfer endpoints.
+- v3 request/response Pydantic models and error handling.
+- REST API tests for auth signatures, query/body placement, and response parsing.
+- WebSocket models for newer documented features: MWallet Pool Quota, Fast Trade, MWallet private channels, and book sequence/version fields `fi`, `li`, and `v`.
+
+## Design Direction
+
+### Package Layout
+
+Add `maicoin/v3/` without replacing `maicoin/v2/`, so existing imports remain compatible.
+
+Suggested structure:
+
+```text
+maicoin/v3/
+  __init__.py
+  auth.py          # payload/signature/header generation
+  client.py        # sync HTTP client and shared request logic
+  errors.py        # API/HTTP errors
+  models.py        # shared enums/base models, or split by domain later
+  public.py        # public endpoints
+  order.py         # order endpoints and models
+  trade.py         # trade endpoints and models
+  wallet.py        # accounts, deposit, withdrawal, m-wallet
+  transaction.py   # fund transactions/transfers/rewards
+  convert.py       # convert endpoints
+```
+
+Start with a synchronous client using the existing `requests` dependency. Add an async client later only if needed.
+
+### Client API
+
+Provide two layers:
+
+1. Low-level `Client.request(method, path, params=None, auth=False)` to centralize base URL, timeout, JSON handling, errors, and authentication.
+2. High-level domain methods, for example:
+   - `client.markets()`
+   - `client.kline(market="btctwd", period=1, limit=30)`
+   - `client.order(market="btctwd", order_id=...)`
+   - `client.create_order(...)`
+
+### Authentication
+
+According to the v3 documentation, private endpoint payloads must include:
+
+- `nonce`
+- request parameters
+- `path`
+
+JSON-serialize that object, Base64-encode it, sign the payload with HMAC-SHA256 using the secret key, and send these headers:
+
+- `X-MAX-ACCESSKEY`
+- `X-MAX-PAYLOAD`
+- `X-MAX-SIGNATURE`
+- `Content-Type: application/json`
+
+GET parameters go in the query string. DELETE/POST/PUT parameters go in the JSON body. Tests should use a fixed nonce so signatures are reproducible.
+
+## Implementation Phases
+
+### Phase 1: v3 Foundation
+
+Create `maicoin/v3/`, auth helpers, sync client, error classes, and basic tests. After this phase, public endpoints should be callable without API credentials.
+
+### Phase 2: v3 Public Endpoints
+
+Implement public endpoints first because they can be tested without real credentials. Prioritize markets, currencies, timestamp, k, depth, trades, tickers, and ticker.
+
+### Phase 3: v3 Private Auth, Accounts, and Orders
+
+Implement auth headers, private request path signing, accounts, open/closed/history orders, create/cancel order, and order trades. This is the minimum useful trading scope.
+
+### Phase 4: Transaction and Funds Features
+
+Add withdrawals, deposits, fund transactions, convert, rewards, and internal transfers. Tests must not send real state-changing requests.
+
+### Phase 5: M-Wallet
+
+Add m-wallet public/private endpoints: index prices, limits, interest rates, loan, repayment, transfers, liquidations, interests, and AD ratio.
+
+### Phase 6: WebSocket Gap Cleanup
+
+Add WebSocket support for MWallet Pool Quota, Fast Trade, MWallet private channels, and book sequence/version fields.
+
+## Acceptance Criteria
+
+Before completing each phase, run at least:
+
+```shell
+poetry run ruff check .
+poetry run pytest -v -s --cov=maicoin --cov-report=xml tests
+```
+
+REST private endpoint tests should use mocked transport/session objects. Do not use real API keys or send real order/withdrawal requests.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,127 @@
+# TODO.md
+
+## Priority Conclusion
+
+The main missing area is **REST API v3**. The repository currently has broad WebSocket support, but REST support only contains `maicoin/v2/kline.py` for `GET /api/v2/k`. The official v3 endpoints, authentication flow, client abstraction, models, and tests still need to be implemented.
+
+## Phase 1: Build the v3 Foundation
+
+- [ ] Add `maicoin/v3/__init__.py`.
+- [ ] Add `maicoin/v3/auth.py`.
+  - [ ] Generate nonce values.
+  - [ ] Build payload content with `nonce`, request params, and `path`.
+  - [ ] JSON-stringify and Base64-encode the payload.
+  - [ ] Generate an HMAC-SHA256 hex signature.
+  - [ ] Generate `X-MAX-ACCESSKEY`, `X-MAX-PAYLOAD`, and `X-MAX-SIGNATURE` headers.
+- [ ] Add `maicoin/v3/client.py`.
+  - [ ] Set `BASE_URL = "https://max-api.maicoin.com"`.
+  - [ ] Set a default timeout.
+  - [ ] Support GET query params.
+  - [ ] Support POST/DELETE/PUT JSON bodies.
+  - [ ] Support public and private requests.
+- [ ] Add `maicoin/v3/errors.py`.
+  - [ ] Handle HTTP status errors.
+  - [ ] Handle MAX API error responses.
+- [ ] Add auth and client unit tests.
+  - [ ] Test signatures with a fixed nonce.
+  - [ ] Test GET params are sent as query params.
+  - [ ] Test POST/DELETE params are sent as JSON bodies.
+
+## Phase 2: REST v3 Public Endpoints
+
+- [ ] `GET /api/v3/markets`: all available markets.
+- [ ] `GET /api/v3/currencies`: currencies.
+- [ ] `GET /api/v3/timestamp`: server timestamp.
+- [ ] `GET /api/v3/k`: K-lines; replace or align with the existing v2 `KLineRequest`.
+- [ ] `GET /api/v3/depth`: order book depth.
+- [ ] `GET /api/v3/trades`: public trades.
+- [ ] `GET /api/v3/tickers`: all tickers.
+- [ ] `GET /api/v3/ticker`: single ticker.
+- [ ] `GET /api/v3/wallet/m/index_prices`: m-wallet index prices.
+- [ ] `GET /api/v3/wallet/m/historical_index_prices`: historical index prices.
+- [ ] `GET /api/v3/wallet/m/limits`: available loan amount.
+- [ ] `GET /api/v3/wallet/m/interest_rates`: interest rates.
+- [ ] Add request construction tests for the endpoints above.
+- [ ] Add Pydantic parsing tests for common responses.
+
+## Phase 3: REST v3 Order, Trade, and Account
+
+- [ ] `GET /api/v3/info`: user info.
+- [ ] `GET /api/v3/wallet/{path_wallet_type}/accounts`: wallet balances.
+- [ ] `GET /api/v3/wallet/{path_wallet_type}/trades`: trade history.
+- [ ] `GET /api/v3/wallet/{path_wallet_type}/orders/open`: open orders.
+- [ ] `GET /api/v3/wallet/{path_wallet_type}/orders/closed`: closed orders.
+- [ ] `GET /api/v3/wallet/{path_wallet_type}/orders/history`: order history by order id.
+- [ ] `POST /api/v3/wallet/{path_wallet_type}/order`: submit a sell/buy order.
+- [ ] `DELETE /api/v3/wallet/{path_wallet_type}/orders`: cancel all orders.
+- [ ] `GET /api/v3/order`: order detail.
+- [ ] `DELETE /api/v3/order`: cancel one order.
+- [ ] `GET /api/v3/order/trades`: order trade detail.
+- [ ] Add order side/type/state enums.
+- [ ] Add create/cancel order tests using mocks only; do not send real trading requests.
+
+## Phase 4: REST v3 Transaction and Wallet Funds
+
+- [ ] `GET /api/v3/withdrawal`: withdrawal detail.
+- [ ] `POST /api/v3/withdrawal`: crypto withdrawal.
+- [ ] `POST /api/v3/withdrawal/twd`: TWD withdrawal.
+- [ ] `GET /api/v3/withdrawals`: withdrawal list.
+- [ ] `GET /api/v3/withdraw_addresses`: withdraw addresses.
+- [ ] `GET /api/v3/deposit`: deposit detail.
+- [ ] `GET /api/v3/deposits`: deposit list.
+- [ ] `GET /api/v3/deposit_address`: deposit address by currency/version.
+- [ ] `GET /api/v3/internal_transfers`: internal transfers.
+- [ ] `GET /api/v3/rewards`: rewards.
+- [ ] `GET /api/v3/fund_transactions/deposits`.
+- [ ] `GET /api/v3/fund_transactions/deposit`.
+- [ ] `GET /api/v3/fund_transactions/withdrawals`.
+- [ ] `GET /api/v3/fund_transactions/withdrawal`.
+- [ ] `GET /api/v3/fund_transactions/transfers`.
+- [ ] `GET /api/v3/fund_transactions/transfer`.
+
+## Phase 5: REST v3 Convert
+
+- [ ] `POST /api/v3/convert`: create convert.
+- [ ] `GET /api/v3/convert`: convert detail.
+- [ ] `GET /api/v3/converts`: convert list.
+- [ ] Add convert request/response models.
+- [ ] Add mocked tests.
+
+## Phase 6: REST v3 M-Wallet Private Endpoints
+
+- [ ] `POST /api/v3/wallet/m/loan`: submit loan.
+- [ ] `GET /api/v3/wallet/m/loans`: loan history.
+- [ ] `POST /api/v3/wallet/m/transfer`: spot wallet to/from m-wallet transfer.
+- [ ] `GET /api/v3/wallet/m/transfers`: m-wallet transfer history.
+- [ ] `POST /api/v3/wallet/m/repayment`: submit repayment.
+- [ ] `GET /api/v3/wallet/m/repayments`: repayment history.
+- [ ] `GET /api/v3/wallet/m/liquidations`: liquidation history.
+- [ ] `GET /api/v3/wallet/m/liquidation`: liquidation detail.
+- [ ] `GET /api/v3/wallet/m/interests`: interest history.
+- [ ] `GET /api/v3/wallet/m/ad_ratio`: latest AD ratio.
+
+## Phase 7: WebSocket Gap Cleanup
+
+- [ ] Add public channel support for MWallet Pool Quota.
+- [ ] Add private channel support for Fast Trade.
+- [ ] Add MWallet private channels: order, trade, fast trade, account, AD ratio, and borrowing.
+- [ ] Add book response fields: `fi`, `li`, and `v`.
+- [ ] Add a `market_status` subscription test.
+- [ ] Check whether `Request.unsubscribe()` serialization should support the documentation's `subscription` versus `subscriptions` difference.
+- [ ] Check whether timestamp, price, and volume fields should preserve string precision instead of always converting to float.
+
+## Documentation
+
+- [ ] Update `README.md` so the HTTP API link points to v3.
+- [ ] Add a REST v3 public client example to README.
+- [ ] Add a REST v3 private auth example to README without real keys.
+- [ ] Keep official documentation links in `AGENTS.md`:
+  - [ ] https://max-api.maicoin.com/doc/v3.html
+  - [ ] https://maicoin.github.io/max-websocket-docs/
+
+## Quality Gate
+
+- [ ] `poetry run ruff check .`
+- [ ] `poetry run pytest -v -s --cov=maicoin --cov-report=xml tests`
+- [ ] Confirm tests do not depend on real MAX API credentials.
+- [ ] Confirm `.env`, API keys, secrets, payloads, and signature logs are not committed.


### PR DESCRIPTION
## Summary
- Add AGENTS.md contributor guidelines with MAX REST v3 and WebSocket documentation links
- Add PLAN.md outlining the REST API v3 implementation approach and WebSocket gaps
- Add TODO.md with phased tasks for v3 endpoints, auth, tests, docs, and WebSocket follow-up

## Tests
- Not run; documentation-only changes