### PR TITLE
feat(v3): add REST API foundation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -17,12 +17,16 @@ Official references:
 - Basic WebSocket private response models for order, trade, and account events.
 - WebSocket auth, subscribe, unsubscribe request models, and stream helper.
 - REST v2: only `GET /api/v2/k` K-line lookup.
-- Tests focused on WebSocket request, response, and subscription model validation.
+- REST v3 foundation package under `maicoin/v3/`.
+- REST API v3 authentication helpers for `X-MAX-ACCESSKEY`, `X-MAX-PAYLOAD`, and `X-MAX-SIGNATURE`.
+- REST API v3 low-level sync `Client.request(...)` using `requests` with public/private request support.
+- REST API v3 HTTP/API error classes.
+- Tests for WebSocket request, response, and subscription model validation.
+- Tests for v3 auth signatures, query/body placement, authenticated headers, and error handling.
 
 ### Missing
 
-- REST API v3 package and public/private client.
-- REST API v3 authentication with `X-MAX-ACCESSKEY`, `X-MAX-PAYLOAD`, and `X-MAX-SIGNATURE`.
+- REST API v3 high-level public/private endpoint wrappers.
 - REST API v3 public endpoints: markets, currencies, timestamp, k, depth, trades, tickers, ticker, index prices, and m-wallet public rates/limits.
 - REST API v3 private endpoints: orders, trades, accounts, withdrawals, deposits, fund transactions, convert, and m-wallet loan/repayment/liquidation/interest/transfer endpoints.
 - v3 request/response Pydantic models and error handling.
@@ -86,7 +90,7 @@ GET parameters go in the query string. DELETE/POST/PUT parameters go in the JSON
 
 ### Phase 1: v3 Foundation
 
-Create `maicoin/v3/`, auth helpers, sync client, error classes, and basic tests. After this phase, public endpoints should be callable without API credentials.
+Complete. `maicoin/v3/` now contains auth helpers, a sync low-level client, error classes, and unit tests. Public endpoints are callable through `Client.request(...)` without API credentials.
 
 ### Phase 2: v3 Public Endpoints
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,58 @@
 # maicoin
 
-A Python package for MaiCoin MAX API
+A Python package for MaiCoin MAX API.
 
 ## Usage
 
-Install package
+Install package:
+
 ```shell
 pip install .
 ```
 
-Create `.env` file
-```
+Create `.env` file for private API examples:
+
+```dotenv
 MAX_API_KEY=
 MAX_API_SECRET=
 ```
 
 Run [example.py](example.py):
+
 ```shell
 python example.py
 ```
+
+## REST API v3
+
+REST v3 support has started with the foundation client, authentication helpers, and error handling. Public endpoint wrappers and typed response models are next.
+
+### Low-level public request
+
+```python
+from maicoin.v3 import Client
+
+client = Client()
+markets = client.request("GET", "/api/v3/markets")
+```
+
+### Low-level private request
+
+Private requests require MAX credentials and are signed with `X-MAX-ACCESSKEY`, `X-MAX-PAYLOAD`, and `X-MAX-SIGNATURE` headers.
+
+```python
+import os
+
+from maicoin.v3 import Client
+
+client = Client(
+    api_key=os.environ["MAX_API_KEY"],
+    api_secret=os.environ["MAX_API_SECRET"],
+)
+accounts = client.request("GET", "/api/v3/wallet/spot/accounts", auth=True)
+```
+
+Do not run state-changing private requests, such as order creation or withdrawals, without reviewing the parameters carefully.
 
 ## To-Do List
 
@@ -36,4 +70,7 @@ python example.py
     - [x] Order
     - [x] Trade
     - [x] Account
-- [ ] [HTTP API](https://max.maicoin.com/documents/api_list/v2)
+- [ ] [HTTP API v3](https://max-api.maicoin.com/doc/v3.html)
+  - [x] Foundation client, authentication helpers, and errors
+  - [ ] Public endpoint wrappers and models
+  - [ ] Private endpoint wrappers and models

--- a/TODO.md
+++ b/TODO.md
@@ -6,26 +6,26 @@ The main missing area is **REST API v3**. The repository currently has broad Web
 
 ## Phase 1: Build the v3 Foundation
 
-- [ ] Add `maicoin/v3/__init__.py`.
-- [ ] Add `maicoin/v3/auth.py`.
-  - [ ] Generate nonce values.
-  - [ ] Build payload content with `nonce`, request params, and `path`.
-  - [ ] JSON-stringify and Base64-encode the payload.
-  - [ ] Generate an HMAC-SHA256 hex signature.
-  - [ ] Generate `X-MAX-ACCESSKEY`, `X-MAX-PAYLOAD`, and `X-MAX-SIGNATURE` headers.
-- [ ] Add `maicoin/v3/client.py`.
-  - [ ] Set `BASE_URL = "https://max-api.maicoin.com"`.
-  - [ ] Set a default timeout.
-  - [ ] Support GET query params.
-  - [ ] Support POST/DELETE/PUT JSON bodies.
-  - [ ] Support public and private requests.
-- [ ] Add `maicoin/v3/errors.py`.
-  - [ ] Handle HTTP status errors.
-  - [ ] Handle MAX API error responses.
-- [ ] Add auth and client unit tests.
-  - [ ] Test signatures with a fixed nonce.
-  - [ ] Test GET params are sent as query params.
-  - [ ] Test POST/DELETE params are sent as JSON bodies.
+- [x] Add `maicoin/v3/__init__.py`.
+- [x] Add `maicoin/v3/auth.py`.
+  - [x] Generate nonce values.
+  - [x] Build payload content with `nonce`, request params, and `path`.
+  - [x] JSON-stringify and Base64-encode the payload.
+  - [x] Generate an HMAC-SHA256 hex signature.
+  - [x] Generate `X-MAX-ACCESSKEY`, `X-MAX-PAYLOAD`, and `X-MAX-SIGNATURE` headers.
+- [x] Add `maicoin/v3/client.py`.
+  - [x] Set `BASE_URL = "https://max-api.maicoin.com"`.
+  - [x] Set a default timeout.
+  - [x] Support GET query params.
+  - [x] Support POST/DELETE/PUT JSON bodies.
+  - [x] Support public and private requests.
+- [x] Add `maicoin/v3/errors.py`.
+  - [x] Handle HTTP status errors.
+  - [x] Handle MAX API error responses.
+- [x] Add auth and client unit tests.
+  - [x] Test signatures with a fixed nonce.
+  - [x] Test GET params are sent as query params.
+  - [x] Test POST/DELETE params are sent as JSON bodies.
 
 ## Phase 2: REST v3 Public Endpoints
 
@@ -112,9 +112,9 @@ The main missing area is **REST API v3**. The repository currently has broad Web
 
 ## Documentation
 
-- [ ] Update `README.md` so the HTTP API link points to v3.
-- [ ] Add a REST v3 public client example to README.
-- [ ] Add a REST v3 private auth example to README without real keys.
+- [x] Update `README.md` so the HTTP API link points to v3.
+- [x] Add a REST v3 public client example to README.
+- [x] Add a REST v3 private auth example to README without real keys.
 - [ ] Keep official documentation links in `AGENTS.md`:
   - [ ] https://max-api.maicoin.com/doc/v3.html
   - [ ] https://maicoin.github.io/max-websocket-docs/

--- a/src/maicoin/v3/__init__.py
+++ b/src/maicoin/v3/__init__.py
@@ -1,0 +1,21 @@
+from .auth import build_auth_headers
+from .auth import encode_payload
+from .auth import generate_nonce
+from .auth import sign_payload
+from .client import BASE_URL
+from .client import DEFAULT_TIMEOUT
+from .client import Client
+from .errors import MaxAPIError
+from .errors import MaxHTTPError
+
+__all__ = [
+    "BASE_URL",
+    "DEFAULT_TIMEOUT",
+    "Client",
+    "MaxAPIError",
+    "MaxHTTPError",
+    "build_auth_headers",
+    "encode_payload",
+    "generate_nonce",
+    "sign_payload",
+]

--- a/src/maicoin/v3/auth.py
+++ b/src/maicoin/v3/auth.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import base64
+import hmac
+import json
+from collections.abc import Mapping
+from datetime import UTC
+from datetime import datetime
+
+
+def generate_nonce() -> int:
+    return int(datetime.now(tz=UTC).timestamp() * 1000)
+
+
+def encode_payload(path: str, params: Mapping[str, object] | None = None, nonce: int | None = None) -> str:
+    payload: dict[str, object] = {"nonce": generate_nonce() if nonce is None else nonce}
+    if params is not None:
+        payload.update(params)
+    payload["path"] = path
+
+    json_payload = json.dumps(payload, separators=(",", ":"))
+    return base64.b64encode(json_payload.encode()).decode()
+
+
+def sign_payload(api_secret: str, payload: str) -> str:
+    return hmac.new(api_secret.encode(), payload.encode(), digestmod="sha256").hexdigest()
+
+
+def build_auth_headers(
+    api_key: str,
+    api_secret: str,
+    path: str,
+    params: Mapping[str, object] | None = None,
+    nonce: int | None = None,
+) -> dict[str, str]:
+    payload = encode_payload(path=path, params=params, nonce=nonce)
+    return {
+        "X-MAX-ACCESSKEY": api_key,
+        "X-MAX-PAYLOAD": payload,
+        "X-MAX-SIGNATURE": sign_payload(api_secret=api_secret, payload=payload),
+        "Content-Type": "application/json",
+    }

--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Mapping
+from typing import Protocol
+from urllib.parse import urljoin
+
+import requests
+
+from .auth import build_auth_headers
+from .auth import generate_nonce
+from .errors import Response
+from .errors import raise_for_api_error
+from .errors import raise_for_response_status
+
+BASE_URL = "https://max-api.maicoin.com"
+DEFAULT_TIMEOUT = 10
+
+
+class RequestSession(Protocol):
+    def request(self, method: str, url: str, **kwargs: object) -> Response: ...
+
+
+class Client:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_secret: str | None = None,
+        *,
+        base_url: str = BASE_URL,
+        timeout: float = DEFAULT_TIMEOUT,
+        session: RequestSession | None = None,
+        nonce_factory: Callable[[], int] = generate_nonce,
+    ) -> None:
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.base_url = base_url
+        self.timeout = timeout
+        self.session = requests.Session() if session is None else session
+        self.nonce_factory = nonce_factory
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        params: Mapping[str, object] | None = None,
+        *,
+        auth: bool = False,
+    ) -> object:
+        normalized_method = method.upper()
+        normalized_path = path if path.startswith("/") else f"/{path}"
+        url = urljoin(self.base_url, normalized_path)
+        request_params = dict(params or {})
+        headers: dict[str, str] = {}
+
+        if auth:
+            if self.api_key is None or self.api_secret is None:
+                msg = "api_key and api_secret are required for authenticated requests"
+                raise ValueError(msg)
+            headers.update(
+                build_auth_headers(
+                    api_key=self.api_key,
+                    api_secret=self.api_secret,
+                    path=normalized_path,
+                    params=request_params,
+                    nonce=self.nonce_factory(),
+                )
+            )
+
+        kwargs: dict[str, object] = {
+            "headers": headers,
+            "timeout": self.timeout,
+        }
+        if normalized_method == "GET":
+            kwargs["params"] = request_params
+        else:
+            kwargs["json"] = request_params
+
+        response = self.session.request(normalized_method, url, **kwargs)
+        raise_for_response_status(response)
+        if not response.content:
+            return None
+
+        payload = response.json()
+        raise_for_api_error(payload)
+        return payload

--- a/src/maicoin/v3/errors.py
+++ b/src/maicoin/v3/errors.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol
+from typing import cast
+
+
+class Response(Protocol):
+    content: bytes
+    status_code: int
+    text: str
+
+    def json(self) -> object: ...
+
+
+class MaxAPIError(Exception):
+    def __init__(self, message: str, *, status_code: int | None = None, payload: object = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.payload = payload
+
+
+class MaxHTTPError(MaxAPIError):
+    pass
+
+
+def raise_for_response_status(response: Response) -> None:
+    status_code = response.status_code
+    if status_code < 400:
+        return
+
+    payload: object
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = getattr(response, "text", "")
+
+    if isinstance(payload, Mapping):
+        payload_mapping = cast("Mapping[object, object]", payload)
+        message = str(payload_mapping.get("error") or payload_mapping.get("message") or payload)
+    else:
+        message = str(payload)
+
+    raise MaxHTTPError(message, status_code=status_code, payload=payload)
+
+
+def raise_for_api_error(payload: object) -> None:
+    if not isinstance(payload, Mapping):
+        return
+
+    payload_mapping = cast("Mapping[object, object]", payload)
+    if "error" not in payload_mapping:
+        return
+
+    raise MaxAPIError(str(payload_mapping["error"]), payload=payload)

--- a/tests/v3/test_auth.py
+++ b/tests/v3/test_auth.py
@@ -1,0 +1,49 @@
+import base64
+import json
+
+from maicoin.v3.auth import build_auth_headers
+from maicoin.v3.auth import encode_payload
+from maicoin.v3.auth import sign_payload
+
+
+def test_encode_payload_with_fixed_nonce() -> None:
+    payload = encode_payload(
+        path="/api/v3/order",
+        params={"market": "btctwd", "side": "bid"},
+        nonce=123456,
+    )
+
+    assert payload == "eyJub25jZSI6MTIzNDU2LCJtYXJrZXQiOiJidGN0d2QiLCJzaWRlIjoiYmlkIiwicGF0aCI6Ii9hcGkvdjMvb3JkZXIifQ=="
+    assert json.loads(base64.b64decode(payload).decode()) == {
+        "nonce": 123456,
+        "market": "btctwd",
+        "side": "bid",
+        "path": "/api/v3/order",
+    }
+
+
+def test_sign_payload() -> None:
+    payload = "eyJub25jZSI6MTIzNDU2LCJtYXJrZXQiOiJidGN0d2QiLCJzaWRlIjoiYmlkIiwicGF0aCI6Ii9hcGkvdjMvb3JkZXIifQ=="
+
+    assert sign_payload(api_secret="secret", payload=payload) == (
+        "a9bf57e0ad199f4ca4325cd0a9af0a82193cb103b1ba5eaaa55b58f79d408ab6"
+    )
+
+
+def test_build_auth_headers() -> None:
+    headers = build_auth_headers(
+        api_key="key",
+        api_secret="secret",
+        path="/api/v3/order",
+        params={"market": "btctwd", "side": "bid"},
+        nonce=123456,
+    )
+
+    assert headers == {
+        "X-MAX-ACCESSKEY": "key",
+        "X-MAX-PAYLOAD": (
+            "eyJub25jZSI6MTIzNDU2LCJtYXJrZXQiOiJidGN0d2QiLCJzaWRlIjoiYmlkIiwicGF0aCI6Ii9hcGkvdjMvb3JkZXIifQ=="
+        ),
+        "X-MAX-SIGNATURE": "a9bf57e0ad199f4ca4325cd0a9af0a82193cb103b1ba5eaaa55b58f79d408ab6",
+        "Content-Type": "application/json",
+    }

--- a/tests/v3/test_client.py
+++ b/tests/v3/test_client.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import cast
+
+import pytest
+
+from maicoin.v3.client import Client
+from maicoin.v3.errors import MaxAPIError
+from maicoin.v3.errors import MaxHTTPError
+
+
+class FakeResponse:
+    def __init__(self, payload: object, *, status_code: int = 200) -> None:
+        self.payload = payload
+        self.status_code = status_code
+        self.content = b"{}"
+        self.text = str(payload)
+
+    def json(self) -> object:
+        return self.payload
+
+
+class FakeSession:
+    def __init__(self, response: FakeResponse) -> None:
+        self.response = response
+        self.calls: list[dict[str, object]] = []
+
+    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        return self.response
+
+
+def last_kwargs(session: FakeSession) -> Mapping[str, object]:
+    return cast("Mapping[str, object]", session.calls[-1]["kwargs"])
+
+
+def test_get_request_sends_params_as_query_params() -> None:
+    session = FakeSession(FakeResponse([{"id": "btctwd"}]))
+    client = Client(base_url="https://example.test", session=session)
+
+    assert client.request("GET", "/api/v3/markets", params={"foo": "bar"}) == [{"id": "btctwd"}]
+
+    assert session.calls[-1]["method"] == "GET"
+    assert session.calls[-1]["url"] == "https://example.test/api/v3/markets"
+    assert last_kwargs(session)["params"] == {"foo": "bar"}
+    assert "json" not in last_kwargs(session)
+
+
+def test_post_request_sends_params_as_json_body() -> None:
+    session = FakeSession(FakeResponse({"id": 1}))
+    client = Client(base_url="https://example.test", session=session)
+
+    assert client.request("POST", "api/v3/order", params={"market": "btctwd"}) == {"id": 1}
+
+    assert session.calls[-1]["method"] == "POST"
+    assert session.calls[-1]["url"] == "https://example.test/api/v3/order"
+    assert last_kwargs(session)["json"] == {"market": "btctwd"}
+    assert "params" not in last_kwargs(session)
+
+
+def test_delete_request_sends_params_as_json_body() -> None:
+    session = FakeSession(FakeResponse({"ok": True}))
+    client = Client(base_url="https://example.test", session=session)
+
+    assert client.request("DELETE", "/api/v3/order", params={"id": 1}) == {"ok": True}
+
+    assert session.calls[-1]["method"] == "DELETE"
+    assert last_kwargs(session)["json"] == {"id": 1}
+    assert "params" not in last_kwargs(session)
+
+
+def test_authenticated_request_adds_max_headers() -> None:
+    session = FakeSession(FakeResponse({"ok": True}))
+    client = Client(
+        api_key="key",
+        api_secret="secret",
+        base_url="https://example.test",
+        session=session,
+        nonce_factory=lambda: 123456,
+    )
+
+    client.request("GET", "/api/v3/wallet/spot/accounts", params={"currency": "btc"}, auth=True)
+
+    headers = cast("Mapping[str, str]", last_kwargs(session)["headers"])
+    assert headers["X-MAX-ACCESSKEY"] == "key"
+    assert headers["X-MAX-PAYLOAD"] == (
+        "eyJub25jZSI6MTIzNDU2LCJjdXJyZW5jeSI6ImJ0YyIsInBhdGgiOiIvYXBpL3YzL3dhbGxldC9zcG90L2FjY291bnRzIn0="
+    )
+    assert headers["X-MAX-SIGNATURE"] == "4347a83e4172fdf36e00c954deacfe143e77a360daef361106ff1ea852cceabe"
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_http_error_response_raises() -> None:
+    client = Client(
+        base_url="https://example.test",
+        session=FakeSession(FakeResponse({"error": "invalid nonce"}, status_code=401)),
+    )
+
+    with pytest.raises(MaxHTTPError, match="invalid nonce"):
+        client.request("GET", "/api/v3/wallet/spot/accounts")
+
+
+def test_api_error_payload_raises() -> None:
+    client = Client(base_url="https://example.test", session=FakeSession(FakeResponse({"error": "bad request"})))
+
+    with pytest.raises(MaxAPIError, match="bad request"):
+        client.request("GET", "/api/v3/ticker")
+
+
+def test_authenticated_request_requires_credentials() -> None:
+    client = Client(base_url="https://example.test", session=FakeSession(FakeResponse({})))
+
+    with pytest.raises(ValueError, match="api_key and api_secret"):
+        client.request("GET", "/api/v3/wallet/spot/accounts", auth=True)


### PR DESCRIPTION
## Summary
- add REST v3 auth helpers for MAX payload/signature headers
- add low-level sync v3 client with public/private request handling and errors
- add v3 auth/client tests and update project docs/TODOs

## Tests
- uv run ruff check .
- uv run ty check
- uv run pytest -q