### PR TITLE
feat(v3): add public REST endpoints

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -21,13 +21,13 @@ Official references:
 - REST API v3 authentication helpers for `X-MAX-ACCESSKEY`, `X-MAX-PAYLOAD`, and `X-MAX-SIGNATURE`.
 - REST API v3 low-level sync `Client.request(...)` using `requests` with public/private request support.
 - REST API v3 HTTP/API error classes.
+- REST API v3 public endpoint wrappers and Pydantic models for markets, currencies, timestamp, k, depth, trades, tickers, ticker, and m-wallet public rates/limits.
 - Tests for WebSocket request, response, and subscription model validation.
-- Tests for v3 auth signatures, query/body placement, authenticated headers, and error handling.
+- Tests for v3 auth signatures, query/body placement, authenticated headers, error handling, public endpoint request construction, and public response parsing.
 
 ### Missing
 
-- REST API v3 high-level public/private endpoint wrappers.
-- REST API v3 public endpoints: markets, currencies, timestamp, k, depth, trades, tickers, ticker, index prices, and m-wallet public rates/limits.
+- REST API v3 high-level private endpoint wrappers.
 - REST API v3 private endpoints: orders, trades, accounts, withdrawals, deposits, fund transactions, convert, and m-wallet loan/repayment/liquidation/interest/transfer endpoints.
 - v3 request/response Pydantic models and error handling.
 - REST API tests for auth signatures, query/body placement, and response parsing.
@@ -94,7 +94,7 @@ Complete. `maicoin/v3/` now contains auth helpers, a sync low-level client, erro
 
 ### Phase 2: v3 Public Endpoints
 
-Implement public endpoints first because they can be tested without real credentials. Prioritize markets, currencies, timestamp, k, depth, trades, tickers, and ticker.
+Complete. Public endpoint wrappers now cover markets, currencies, timestamp, k, depth, trades, tickers, ticker, and m-wallet public index/limit/rate endpoints with Pydantic parsing tests.
 
 ### Phase 3: v3 Private Auth, Accounts, and Orders
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,20 @@ python example.py
 
 ## REST API v3
 
-REST v3 support has started with the foundation client, authentication helpers, and error handling. Public endpoint wrappers and typed response models are next.
+REST v3 support includes the foundation client, authentication helpers, error handling, public endpoint wrappers, and typed public response models.
 
-### Low-level public request
+### Public requests
+
+```python
+from maicoin.v3 import Client
+
+client = Client()
+markets = client.markets()
+ticker = client.ticker("btctwd")
+klines = client.kline("btctwd", period=1, limit=30)
+```
+
+Use `Client.request(...)` for low-level access when a high-level wrapper is not available yet:
 
 ```python
 from maicoin.v3 import Client
@@ -72,5 +83,5 @@ Do not run state-changing private requests, such as order creation or withdrawal
     - [x] Account
 - [ ] [HTTP API v3](https://max-api.maicoin.com/doc/v3.html)
   - [x] Foundation client, authentication helpers, and errors
-  - [ ] Public endpoint wrappers and models
+  - [x] Public endpoint wrappers and models
   - [ ] Private endpoint wrappers and models

--- a/TODO.md
+++ b/TODO.md
@@ -29,20 +29,20 @@ The main missing area is **REST API v3**. The repository currently has broad Web
 
 ## Phase 2: REST v3 Public Endpoints
 
-- [ ] `GET /api/v3/markets`: all available markets.
-- [ ] `GET /api/v3/currencies`: currencies.
-- [ ] `GET /api/v3/timestamp`: server timestamp.
-- [ ] `GET /api/v3/k`: K-lines; replace or align with the existing v2 `KLineRequest`.
-- [ ] `GET /api/v3/depth`: order book depth.
-- [ ] `GET /api/v3/trades`: public trades.
-- [ ] `GET /api/v3/tickers`: all tickers.
-- [ ] `GET /api/v3/ticker`: single ticker.
-- [ ] `GET /api/v3/wallet/m/index_prices`: m-wallet index prices.
-- [ ] `GET /api/v3/wallet/m/historical_index_prices`: historical index prices.
-- [ ] `GET /api/v3/wallet/m/limits`: available loan amount.
-- [ ] `GET /api/v3/wallet/m/interest_rates`: interest rates.
-- [ ] Add request construction tests for the endpoints above.
-- [ ] Add Pydantic parsing tests for common responses.
+- [x] `GET /api/v3/markets`: all available markets.
+- [x] `GET /api/v3/currencies`: currencies.
+- [x] `GET /api/v3/timestamp`: server timestamp.
+- [x] `GET /api/v3/k`: K-lines; replace or align with the existing v2 `KLineRequest`.
+- [x] `GET /api/v3/depth`: order book depth.
+- [x] `GET /api/v3/trades`: public trades.
+- [x] `GET /api/v3/tickers`: all tickers.
+- [x] `GET /api/v3/ticker`: single ticker.
+- [x] `GET /api/v3/wallet/m/index_prices`: m-wallet index prices.
+- [x] `GET /api/v3/wallet/m/historical_index_prices`: historical index prices.
+- [x] `GET /api/v3/wallet/m/limits`: available loan amount.
+- [x] `GET /api/v3/wallet/m/interest_rates`: interest rates.
+- [x] Add request construction tests for the endpoints above.
+- [x] Add Pydantic parsing tests for common responses.
 
 ## Phase 3: REST v3 Order, Trade, and Account
 

--- a/src/maicoin/v3/__init__.py
+++ b/src/maicoin/v3/__init__.py
@@ -7,13 +7,35 @@ from .client import DEFAULT_TIMEOUT
 from .client import Client
 from .errors import MaxAPIError
 from .errors import MaxHTTPError
+from .models import Currency
+from .models import CurrencyNetwork
+from .models import Depth
+from .models import HistoricalIndexPrice
+from .models import InterestRate
+from .models import KLine
+from .models import Market
+from .models import PublicTrade
+from .models import Staking
+from .models import Ticker
+from .models import Timestamp
 
 __all__ = [
     "BASE_URL",
     "DEFAULT_TIMEOUT",
     "Client",
+    "Currency",
+    "CurrencyNetwork",
+    "Depth",
+    "HistoricalIndexPrice",
+    "InterestRate",
+    "KLine",
+    "Market",
     "MaxAPIError",
     "MaxHTTPError",
+    "PublicTrade",
+    "Staking",
+    "Ticker",
+    "Timestamp",
     "build_auth_headers",
     "encode_payload",
     "generate_nonce",

--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from collections.abc import Mapping
+from collections.abc import Sequence
 from typing import Protocol
+from typing import cast
 from urllib.parse import urljoin
 
 import requests
@@ -12,9 +14,22 @@ from .auth import generate_nonce
 from .errors import Response
 from .errors import raise_for_api_error
 from .errors import raise_for_response_status
+from .models import Currency
+from .models import Depth
+from .models import HistoricalIndexPrice
+from .models import InterestRate
+from .models import KLine
+from .models import Market
+from .models import PublicTrade
+from .models import Ticker
+from .models import Timestamp
 
 BASE_URL = "https://max-api.maicoin.com"
 DEFAULT_TIMEOUT = 10
+
+
+def _compact(params: Mapping[str, object | None]) -> dict[str, object]:
+    return {key: value for key, value in params.items() if value is not None}
 
 
 class RequestSession(Protocol):
@@ -84,3 +99,92 @@ class Client:
         payload = response.json()
         raise_for_api_error(payload)
         return payload
+
+    def markets(self) -> list[Market]:
+        payload = self.request("GET", "/api/v3/markets")
+        return [Market.model_validate(item) for item in cast("list[object]", payload)]
+
+    def currencies(self) -> list[Currency]:
+        payload = self.request("GET", "/api/v3/currencies")
+        return [Currency.model_validate(item) for item in cast("list[object]", payload)]
+
+    def timestamp(self) -> Timestamp:
+        payload = self.request("GET", "/api/v3/timestamp")
+        return Timestamp.model_validate(payload)
+
+    def kline(
+        self,
+        market: str,
+        *,
+        limit: int = 30,
+        period: int = 1,
+        timestamp: int | None = None,
+    ) -> list[KLine]:
+        payload = self.request(
+            "GET",
+            "/api/v3/k",
+            params=_compact({"market": market, "limit": limit, "period": period, "timestamp": timestamp}),
+        )
+        return [
+            KLine(
+                timestamp=int(str(row[0])),
+                open=str(row[1]),
+                high=str(row[2]),
+                low=str(row[3]),
+                close=str(row[4]),
+                volume=str(row[5]),
+            )
+            for row in cast("list[Sequence[object]]", payload)
+        ]
+
+    def depth(self, market: str, *, limit: int | None = None, sort_by_price: bool | None = None) -> Depth:
+        payload = self.request(
+            "GET",
+            "/api/v3/depth",
+            params=_compact({"market": market, "limit": limit, "sort_by_price": sort_by_price}),
+        )
+        return Depth.model_validate(payload)
+
+    def trades(self, market: str, *, timestamp: int | None = None, limit: int | None = None) -> list[PublicTrade]:
+        payload = self.request(
+            "GET",
+            "/api/v3/trades",
+            params=_compact({"market": market, "timestamp": timestamp, "limit": limit}),
+        )
+        return [PublicTrade.model_validate(item) for item in cast("list[object]", payload)]
+
+    def tickers(self, markets: Sequence[str]) -> list[Ticker]:
+        payload = self.request("GET", "/api/v3/tickers", params={"markets[]": list(markets)})
+        return [Ticker.model_validate(item) for item in cast("list[object]", payload)]
+
+    def ticker(self, market: str) -> Ticker:
+        payload = self.request("GET", "/api/v3/ticker", params={"market": market})
+        return Ticker.model_validate(payload)
+
+    def m_wallet_index_prices(self) -> dict[str, str]:
+        payload = self.request("GET", "/api/v3/wallet/m/index_prices")
+        return cast("dict[str, str]", payload)
+
+    def m_wallet_historical_index_prices(
+        self,
+        market: str,
+        *,
+        start_time: int,
+        end_time: int,
+    ) -> list[HistoricalIndexPrice]:
+        payload = self.request(
+            "GET",
+            "/api/v3/wallet/m/historical_index_prices",
+            params={"market": market, "start_time": start_time, "end_time": end_time},
+        )
+        return [HistoricalIndexPrice.model_validate(item) for item in cast("list[object]", payload)]
+
+    def m_wallet_limits(self) -> dict[str, str]:
+        payload = self.request("GET", "/api/v3/wallet/m/limits")
+        return cast("dict[str, str]", payload)
+
+    def m_wallet_interest_rates(self) -> dict[str, InterestRate]:
+        payload = self.request("GET", "/api/v3/wallet/m/interest_rates")
+        return {
+            currency: InterestRate.model_validate(rate) for currency, rate in cast("dict[str, object]", payload).items()
+        }

--- a/src/maicoin/v3/models.py
+++ b/src/maicoin/v3/models.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+
+
+class MaxBaseModel(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class Market(MaxBaseModel):
+    id: str
+    status: str
+    base_unit: str
+    base_unit_precision: int
+    min_base_amount: float
+    quote_unit: str
+    quote_unit_precision: int
+    min_quote_amount: float
+    m_wallet_supported: bool
+
+
+class Staking(MaxBaseModel):
+    stake_flag: bool
+    unstake_flag: bool
+
+
+class CurrencyNetwork(MaxBaseModel):
+    token_contract_address: str
+    precision: int
+    id: str
+    network_protocol: str
+    network_congested: bool | str
+    deposit_confirmations: int
+    withdrawal_fee: float
+    min_withdrawal_amount: float
+    withdrawal_enabled: bool
+    deposit_enabled: bool
+    need_memo: bool
+
+
+class Currency(MaxBaseModel):
+    currency: str
+    type: str
+    precision: int
+    m_wallet_supported: bool
+    m_wallet_mortgageable: bool
+    m_wallet_borrowable: bool
+    min_borrow_amount: str
+    networks: list[CurrencyNetwork]
+    staking: Staking | None
+
+
+class Timestamp(MaxBaseModel):
+    timestamp: int
+
+
+class KLine(MaxBaseModel):
+    timestamp: int
+    open: str
+    high: str
+    low: str
+    close: str
+    volume: str
+
+
+class Depth(MaxBaseModel):
+    timestamp: int
+    asks: list[tuple[str, str]]
+    bids: list[tuple[str, str]]
+    last_update_version: int | None = None
+    last_update_id: int | None = None
+
+
+class PublicTrade(MaxBaseModel):
+    id: int
+    price: str
+    volume: str
+    funds: str
+    market: str
+    side: str
+    created_at: int
+
+
+class Ticker(MaxBaseModel):
+    market: str
+    at: int
+    buy: str
+    buy_vol: str
+    sell: str
+    sell_vol: str
+    open: str
+    low: str
+    high: str
+    last: str
+    vol: str
+    vol_in_btc: str
+    vol_in_quote: str
+
+
+class HistoricalIndexPrice(MaxBaseModel):
+    timestamp: str
+    price: str
+
+
+class InterestRate(MaxBaseModel):
+    hourly_interest_rate: str
+    next_hourly_interest_rate: str

--- a/tests/v3/test_public.py
+++ b/tests/v3/test_public.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import cast
+
+from maicoin.v3 import Client
+from maicoin.v3 import Depth
+from maicoin.v3 import InterestRate
+from maicoin.v3 import KLine
+from maicoin.v3 import Market
+from maicoin.v3 import Ticker
+
+
+class FakeResponse:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+        self.status_code = 200
+        self.content = b"{}"
+        self.text = str(payload)
+
+    def json(self) -> object:
+        return self.payload
+
+
+class FakeSession:
+    def __init__(self, payload: object) -> None:
+        self.response = FakeResponse(payload)
+        self.calls: list[dict[str, object]] = []
+
+    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        return self.response
+
+
+def last_params(session: FakeSession) -> Mapping[str, object]:
+    kwargs = cast("Mapping[str, object]", session.calls[-1]["kwargs"])
+    return cast("Mapping[str, object]", kwargs["params"])
+
+
+def test_markets_returns_market_models() -> None:
+    session = FakeSession(
+        [
+            {
+                "id": "btctwd",
+                "status": "active",
+                "base_unit": "btc",
+                "base_unit_precision": 8,
+                "min_base_amount": 0.0004,
+                "quote_unit": "twd",
+                "quote_unit_precision": 1,
+                "min_quote_amount": 250,
+                "m_wallet_supported": True,
+            }
+        ]
+    )
+    client = Client(base_url="https://example.test", session=session)
+
+    markets = client.markets()
+
+    assert markets == [
+        Market(
+            id="btctwd",
+            status="active",
+            base_unit="btc",
+            base_unit_precision=8,
+            min_base_amount=0.0004,
+            quote_unit="twd",
+            quote_unit_precision=1,
+            min_quote_amount=250,
+            m_wallet_supported=True,
+        )
+    ]
+    assert session.calls[-1]["url"] == "https://example.test/api/v3/markets"
+
+
+def test_currencies_returns_currency_models() -> None:
+    session = FakeSession(
+        [
+            {
+                "currency": "usdt",
+                "type": "crypto",
+                "precision": 8,
+                "m_wallet_supported": True,
+                "m_wallet_mortgageable": True,
+                "m_wallet_borrowable": True,
+                "min_borrow_amount": "0.001",
+                "networks": [
+                    {
+                        "token_contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+                        "precision": 8,
+                        "id": "trc20usdt",
+                        "network_protocol": "tron-trc20",
+                        "network_congested": False,
+                        "deposit_confirmations": 3,
+                        "withdrawal_fee": 0.0005,
+                        "min_withdrawal_amount": 0.001,
+                        "withdrawal_enabled": True,
+                        "deposit_enabled": True,
+                        "need_memo": False,
+                    }
+                ],
+                "staking": None,
+            }
+        ]
+    )
+    client = Client(base_url="https://example.test", session=session)
+
+    currencies = client.currencies()
+
+    assert currencies[0].currency == "usdt"
+    assert currencies[0].networks[0].id == "trc20usdt"
+    assert currencies[0].staking is None
+
+
+def test_timestamp_returns_timestamp_model() -> None:
+    client = Client(base_url="https://example.test", session=FakeSession({"timestamp": 1678766175}))
+
+    assert client.timestamp().timestamp == 1678766175
+
+
+def test_kline_constructs_params_and_parses_rows() -> None:
+    session = FakeSession([[1678766100, "1", "2", "0.5", "1.5", "42"]])
+    client = Client(base_url="https://example.test", session=session)
+
+    klines = client.kline("btctwd", limit=1, period=5, timestamp=1678766100)
+
+    assert klines == [KLine(timestamp=1678766100, open="1", high="2", low="0.5", close="1.5", volume="42")]
+    assert last_params(session) == {"market": "btctwd", "limit": 1, "period": 5, "timestamp": 1678766100}
+
+
+def test_depth_constructs_params_and_parses_depth() -> None:
+    session = FakeSession(
+        {
+            "timestamp": 1778249163,
+            "last_update_version": 1778220148899,
+            "last_update_id": 556021,
+            "asks": [["2520230.1", "0.00128053"]],
+            "bids": [["2520028.3", "0.11903796"]],
+        }
+    )
+    client = Client(base_url="https://example.test", session=session)
+
+    depth = client.depth("btctwd", limit=1, sort_by_price=True)
+
+    assert depth == Depth(
+        timestamp=1778249163,
+        last_update_version=1778220148899,
+        last_update_id=556021,
+        asks=[("2520230.1", "0.00128053")],
+        bids=[("2520028.3", "0.11903796")],
+    )
+    assert last_params(session) == {"market": "btctwd", "limit": 1, "sort_by_price": True}
+
+
+def test_trades_constructs_params_and_parses_trades() -> None:
+    session = FakeSession(
+        [
+            {
+                "id": 68444,
+                "price": "21499.0",
+                "volume": "0.2658",
+                "funds": "5714.4",
+                "market": "ethtwd",
+                "side": "bid",
+                "created_at": 1521726960357,
+            }
+        ]
+    )
+    client = Client(base_url="https://example.test", session=session)
+
+    trades = client.trades("ethtwd", timestamp=1521726960357, limit=1)
+
+    assert trades[0].id == 68444
+    assert trades[0].side == "bid"
+    assert last_params(session) == {"market": "ethtwd", "timestamp": 1521726960357, "limit": 1}
+
+
+def test_tickers_uses_bracket_array_param_and_parses_tickers() -> None:
+    ticker_payload = {
+        "market": "btctwd",
+        "at": 1531905257,
+        "buy": "200000.0",
+        "buy_vol": "0.01",
+        "sell": "200001.0",
+        "sell_vol": "0.02",
+        "open": "199000.0",
+        "low": "198000.0",
+        "high": "201000.0",
+        "last": "200500.0",
+        "vol": "10.0",
+        "vol_in_btc": "10.0",
+        "vol_in_quote": "2005000.0",
+    }
+    session = FakeSession([ticker_payload])
+    client = Client(base_url="https://example.test", session=session)
+
+    tickers = client.tickers(["btctwd", "ethusdt"])
+
+    assert tickers == [Ticker.model_validate(ticker_payload)]
+    assert last_params(session) == {"markets[]": ["btctwd", "ethusdt"]}
+
+
+def test_ticker_constructs_params_and_parses_ticker() -> None:
+    session = FakeSession(
+        {
+            "market": "btctwd",
+            "at": 1531905257,
+            "buy": "200000.0",
+            "buy_vol": "0.01",
+            "sell": "200001.0",
+            "sell_vol": "0.02",
+            "open": "199000.0",
+            "low": "198000.0",
+            "high": "201000.0",
+            "last": "200500.0",
+            "vol": "10.0",
+            "vol_in_btc": "10.0",
+            "vol_in_quote": "2005000.0",
+        }
+    )
+    client = Client(base_url="https://example.test", session=session)
+
+    ticker = client.ticker("btctwd")
+
+    assert ticker.market == "btctwd"
+    assert last_params(session) == {"market": "btctwd"}
+
+
+def test_m_wallet_public_methods_parse_payloads() -> None:
+    assert Client(session=FakeSession({"btcusdt": "79848.60666667"})).m_wallet_index_prices() == {
+        "btcusdt": "79848.60666667"
+    }
+    assert Client(session=FakeSession({"btc": "10.67520286"})).m_wallet_limits() == {"btc": "10.67520286"}
+
+    rates = Client(
+        session=FakeSession({"btc": {"hourly_interest_rate": "0.00000126", "next_hourly_interest_rate": "0.00000126"}})
+    ).m_wallet_interest_rates()
+    assert rates == {"btc": InterestRate(hourly_interest_rate="0.00000126", next_hourly_interest_rate="0.00000126")}
+
+
+def test_m_wallet_historical_index_prices_constructs_params_and_parses_prices() -> None:
+    session = FakeSession([{"timestamp": "1644572610000", "price": "43497.56666666"}])
+    client = Client(base_url="https://example.test", session=session)
+
+    prices = client.m_wallet_historical_index_prices("btcusdt", start_time=1644572610000, end_time=1644572670000)
+
+    assert prices[0].timestamp == "1644572610000"
+    assert prices[0].price == "43497.56666666"
+    assert last_params(session) == {"market": "btcusdt", "start_time": 1644572610000, "end_time": 1644572670000}


### PR DESCRIPTION
## Summary
- add typed Pydantic models for REST v3 public responses
- add high-level public client wrappers for markets, currencies, ticker, kline, depth, trades, and m-wallet public endpoints
- add request construction and response parsing tests for public endpoints
- update README, PLAN, and TODO for Phase 2 progress

## Tests
- uv run ruff check .
- uv run ty check
- uv run pytest -q