### PR TITLE
feat(v3): add private account and order endpoints

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -22,15 +22,14 @@ Official references:
 - REST API v3 low-level sync `Client.request(...)` using `httpx` with public/private request support.
 - REST API v3 HTTP/API error classes.
 - REST API v3 public endpoint wrappers and Pydantic models for markets, currencies, timestamp, k, depth, trades, tickers, ticker, and m-wallet public rates/limits.
+- REST API v3 private endpoint wrappers and models for accounts, open/closed/history orders, create/cancel order, and order trades.
 - Tests for WebSocket request, response, and subscription model validation.
-- Tests for v3 auth signatures, query/body placement, authenticated headers, error handling, public endpoint request construction, and public response parsing.
+- Tests for v3 auth signatures, query/body placement, authenticated headers, error handling, public/private endpoint request construction, and response parsing.
 
 ### Missing
 
-- REST API v3 high-level private endpoint wrappers.
-- REST API v3 private endpoints: orders, trades, accounts, withdrawals, deposits, fund transactions, convert, and m-wallet loan/repayment/liquidation/interest/transfer endpoints.
-- v3 request/response Pydantic models and error handling.
-- REST API tests for private endpoint wrappers and response parsing.
+- REST API v3 private endpoints: withdrawals, deposits, fund transactions, convert, and m-wallet loan/repayment/liquidation/interest/transfer endpoints.
+- REST API tests for withdrawals, deposits, fund transactions, convert, and m-wallet private endpoint wrappers and response parsing.
 - WebSocket models for newer documented features: MWallet Pool Quota, Fast Trade, MWallet private channels, and book sequence/version fields `fi`, `li`, and `v`.
 
 ## Design Direction
@@ -98,7 +97,7 @@ Complete. Public endpoint wrappers now cover markets, currencies, timestamp, k, 
 
 ### Phase 3: v3 Private Auth, Accounts, and Orders
 
-Implement auth headers, private request path signing, accounts, open/closed/history orders, create/cancel order, and order trades. This is the minimum useful trading scope.
+Complete. Authenticated client wrappers now cover accounts, open/closed/history orders, order lookup, create/cancel order, cancel all orders, and order trades with Pydantic parsing tests.
 
 ### Phase 4: Transaction and Funds Features
 

--- a/src/maicoin/v3/__init__.py
+++ b/src/maicoin/v3/__init__.py
@@ -7,6 +7,7 @@ from .client import DEFAULT_TIMEOUT
 from .client import Client
 from .errors import MaxAPIError
 from .errors import MaxHTTPError
+from .models import Account
 from .models import Currency
 from .models import CurrencyNetwork
 from .models import Depth
@@ -14,6 +15,8 @@ from .models import HistoricalIndexPrice
 from .models import InterestRate
 from .models import KLine
 from .models import Market
+from .models import Order
+from .models import PrivateTrade
 from .models import PublicTrade
 from .models import Staking
 from .models import Ticker
@@ -22,6 +25,7 @@ from .models import Timestamp
 __all__ = [
     "BASE_URL",
     "DEFAULT_TIMEOUT",
+    "Account",
     "Client",
     "Currency",
     "CurrencyNetwork",
@@ -32,6 +36,8 @@ __all__ = [
     "Market",
     "MaxAPIError",
     "MaxHTTPError",
+    "Order",
+    "PrivateTrade",
     "PublicTrade",
     "Staking",
     "Ticker",

--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -14,12 +14,15 @@ from .auth import generate_nonce
 from .errors import Response
 from .errors import raise_for_api_error
 from .errors import raise_for_response_status
+from .models import Account
 from .models import Currency
 from .models import Depth
 from .models import HistoricalIndexPrice
 from .models import InterestRate
 from .models import KLine
 from .models import Market
+from .models import Order
+from .models import PrivateTrade
 from .models import PublicTrade
 from .models import Ticker
 from .models import Timestamp
@@ -160,6 +163,140 @@ class Client:
     def ticker(self, market: str) -> Ticker:
         payload = self.request("GET", "/api/v3/ticker", params={"market": market})
         return Ticker.model_validate(payload)
+
+    def accounts(self, *, wallet_type: str = "spot", currency: str | None = None) -> list[Account]:
+        payload = self.request(
+            "GET",
+            f"/api/v3/wallet/{wallet_type}/accounts",
+            params=_compact({"currency": currency}),
+            auth=True,
+        )
+        return [Account.model_validate(item) for item in cast("list[object]", payload)]
+
+    def open_orders(
+        self,
+        *,
+        wallet_type: str = "spot",
+        market: str | None = None,
+        timestamp: int | None = None,
+        order_by: str | None = None,
+        limit: int | None = None,
+    ) -> list[Order]:
+        payload = self.request(
+            "GET",
+            f"/api/v3/wallet/{wallet_type}/orders/open",
+            params=_compact({"market": market, "timestamp": timestamp, "order_by": order_by, "limit": limit}),
+            auth=True,
+        )
+        return [Order.model_validate(item) for item in cast("list[object]", payload)]
+
+    def closed_orders(
+        self,
+        *,
+        wallet_type: str = "spot",
+        market: str | None = None,
+        timestamp: int | None = None,
+        order_by: str | None = None,
+        limit: int | None = None,
+    ) -> list[Order]:
+        payload = self.request(
+            "GET",
+            f"/api/v3/wallet/{wallet_type}/orders/closed",
+            params=_compact({"market": market, "timestamp": timestamp, "order_by": order_by, "limit": limit}),
+            auth=True,
+        )
+        return [Order.model_validate(item) for item in cast("list[object]", payload)]
+
+    def order_history(
+        self,
+        market: str,
+        *,
+        wallet_type: str = "spot",
+        from_id: int | None = None,
+        limit: int | None = None,
+    ) -> list[Order]:
+        payload = self.request(
+            "GET",
+            f"/api/v3/wallet/{wallet_type}/orders/history",
+            params=_compact({"market": market, "from_id": from_id, "limit": limit}),
+            auth=True,
+        )
+        return [Order.model_validate(item) for item in cast("list[object]", payload)]
+
+    def order(self, *, order_id: int | None = None, client_oid: str | None = None) -> Order:
+        payload = self.request(
+            "GET",
+            "/api/v3/order",
+            params=_compact({"id": order_id, "client_oid": client_oid}),
+            auth=True,
+        )
+        return Order.model_validate(payload)
+
+    def create_order(
+        self,
+        market: str,
+        side: str,
+        volume: str,
+        *,
+        wallet_type: str = "spot",
+        price: str | None = None,
+        client_oid: str | None = None,
+        stop_price: str | None = None,
+        ord_type: str | None = None,
+        group_id: int | None = None,
+    ) -> Order:
+        payload = self.request(
+            "POST",
+            f"/api/v3/wallet/{wallet_type}/order",
+            params=_compact(
+                {
+                    "market": market,
+                    "side": side,
+                    "volume": volume,
+                    "price": price,
+                    "client_oid": client_oid,
+                    "stop_price": stop_price,
+                    "ord_type": ord_type,
+                    "group_id": group_id,
+                }
+            ),
+            auth=True,
+        )
+        return Order.model_validate(payload)
+
+    def cancel_order(self, *, order_id: int | None = None, client_oid: str | None = None) -> Order:
+        payload = self.request(
+            "DELETE",
+            "/api/v3/order",
+            params=_compact({"id": order_id, "client_oid": client_oid}),
+            auth=True,
+        )
+        return Order.model_validate(payload)
+
+    def cancel_orders(
+        self,
+        *,
+        wallet_type: str = "spot",
+        market: str | None = None,
+        side: str | None = None,
+        group_id: int | None = None,
+    ) -> list[Order]:
+        payload = self.request(
+            "DELETE",
+            f"/api/v3/wallet/{wallet_type}/orders",
+            params=_compact({"market": market, "side": side, "group_id": group_id}),
+            auth=True,
+        )
+        return [Order.model_validate(item) for item in cast("list[object]", payload)]
+
+    def order_trades(self, *, order_id: int | None = None, client_oid: str | None = None) -> list[PrivateTrade]:
+        payload = self.request(
+            "GET",
+            "/api/v3/order/trades",
+            params=_compact({"order_id": order_id, "client_oid": client_oid}),
+            auth=True,
+        )
+        return [PrivateTrade.model_validate(item) for item in cast("list[object]", payload)]
 
     def m_wallet_index_prices(self) -> dict[str, str]:
         payload = self.request("GET", "/api/v3/wallet/m/index_prices")

--- a/src/maicoin/v3/models.py
+++ b/src/maicoin/v3/models.py
@@ -82,6 +82,56 @@ class PublicTrade(MaxBaseModel):
     created_at: int
 
 
+class Account(MaxBaseModel):
+    currency: str
+    balance: str
+    locked: str
+    staked: str | None = None
+    principal: str | None = None
+    interest: str | None = None
+
+
+class Order(MaxBaseModel):
+    id: int
+    wallet_type: str
+    market: str
+    client_oid: str | None = None
+    group_id: int | None = None
+    side: str
+    state: str
+    ord_type: str
+    price: str | None = None
+    stop_price: str | None = None
+    avg_price: str
+    volume: str
+    remaining_volume: str
+    executed_volume: str
+    trades_count: int
+    created_at: int
+    updated_at: int
+
+
+class PrivateTrade(MaxBaseModel):
+    id: int
+    order_id: int
+    wallet_type: str
+    price: str
+    volume: str
+    funds: str
+    market: str
+    market_name: str
+    side: str
+    fee: str | None = None
+    fee_currency: str | None = None
+    fee_discounted: bool | None = None
+    self_trade_bid_fee: str | None = None
+    self_trade_bid_fee_currency: str | None = None
+    self_trade_bid_fee_discounted: bool | None = None
+    self_trade_bid_order_id: int | None = None
+    liquidity: str
+    created_at: int
+
+
 class Ticker(MaxBaseModel):
     market: str
     at: int

--- a/tests/v3/test_private.py
+++ b/tests/v3/test_private.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Mapping
+from typing import cast
+
+from maicoin.v3 import Account
+from maicoin.v3 import Client
+from maicoin.v3 import Order
+from maicoin.v3 import PrivateTrade
+
+
+class FakeResponse:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+        self.status_code = 200
+        self.content = b"{}"
+        self.text = str(payload)
+
+    def json(self) -> object:
+        return self.payload
+
+
+class FakeSession:
+    def __init__(self, payload: object) -> None:
+        self.response = FakeResponse(payload)
+        self.calls: list[dict[str, object]] = []
+
+    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        return self.response
+
+
+def last_kwargs(session: FakeSession) -> Mapping[str, object]:
+    return cast("Mapping[str, object]", session.calls[-1]["kwargs"])
+
+
+def last_payload(session: FakeSession) -> Mapping[str, object]:
+    headers = cast("Mapping[str, str]", last_kwargs(session)["headers"])
+    payload = base64.b64decode(headers["X-MAX-PAYLOAD"]).decode()
+    return cast("Mapping[str, object]", json.loads(payload))
+
+
+def authenticated_client(session: FakeSession) -> Client:
+    return Client(
+        api_key="key",
+        api_secret="secret",
+        base_url="https://example.test",
+        session=session,
+        nonce_factory=lambda: 123456,
+    )
+
+
+def order_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": 87,
+        "wallet_type": "spot",
+        "market": "ethtwd",
+        "client_oid": "client-1",
+        "group_id": 1,
+        "side": "buy",
+        "state": "wait",
+        "ord_type": "limit",
+        "price": "21499.0",
+        "stop_price": None,
+        "avg_price": "0.0",
+        "volume": "0.2658",
+        "remaining_volume": "0.2658",
+        "executed_volume": "0.0",
+        "trades_count": 0,
+        "created_at": 1521726960123,
+        "updated_at": 1521726960123,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_accounts_constructs_authenticated_request_and_parses_accounts() -> None:
+    session = FakeSession([{"currency": "twd", "balance": "100000.0", "locked": "5566.0", "staked": None}])
+    client = authenticated_client(session)
+
+    accounts = client.accounts(currency="twd")
+
+    assert accounts == [Account(currency="twd", balance="100000.0", locked="5566.0", staked=None)]
+    assert session.calls[-1]["method"] == "GET"
+    assert session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/accounts"
+    assert last_kwargs(session)["params"] == {"currency": "twd"}
+    assert last_payload(session) == {
+        "nonce": 123456,
+        "currency": "twd",
+        "path": "/api/v3/wallet/spot/accounts",
+    }
+
+
+def test_open_closed_and_history_orders_parse_order_models() -> None:
+    expected_order = Order.model_validate(order_payload())
+
+    open_session = FakeSession([order_payload()])
+    assert authenticated_client(open_session).open_orders(market="ethtwd", limit=1) == [expected_order]
+    assert open_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/orders/open"
+    assert last_kwargs(open_session)["params"] == {"market": "ethtwd", "limit": 1}
+
+    closed_session = FakeSession([order_payload(state="done")])
+    assert authenticated_client(closed_session).closed_orders(wallet_type="m")[0].state == "done"
+    assert closed_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/orders/closed"
+
+    history_session = FakeSession([order_payload()])
+    history = authenticated_client(history_session).order_history("ethtwd", from_id=10, limit=50)
+    assert history == [expected_order]
+    assert last_kwargs(history_session)["params"] == {"market": "ethtwd", "from_id": 10, "limit": 50}
+
+
+def test_order_lookup_and_order_trades_construct_requests() -> None:
+    order_session = FakeSession(order_payload())
+    order = authenticated_client(order_session).order(order_id=87)
+
+    assert order.id == 87
+    assert order_session.calls[-1]["url"] == "https://example.test/api/v3/order"
+    assert last_kwargs(order_session)["params"] == {"id": 87}
+
+    trade_payload = {
+        "id": 68444,
+        "order_id": 87,
+        "wallet_type": "spot",
+        "price": "21499.0",
+        "volume": "0.2658",
+        "funds": "5714.4",
+        "market": "ethtwd",
+        "market_name": "ETH/TWD",
+        "side": "bid",
+        "fee": "0.00001",
+        "fee_currency": "usdt",
+        "fee_discounted": False,
+        "liquidity": "taker",
+        "created_at": 1521726960357,
+    }
+    trade_session = FakeSession([trade_payload])
+    trades = authenticated_client(trade_session).order_trades(client_oid="client-1")
+
+    assert trades == [PrivateTrade.model_validate(trade_payload)]
+    assert trade_session.calls[-1]["url"] == "https://example.test/api/v3/order/trades"
+    assert last_kwargs(trade_session)["params"] == {"client_oid": "client-1"}
+
+
+def test_create_and_cancel_order_send_authenticated_json_body() -> None:
+    create_session = FakeSession(order_payload())
+    created = authenticated_client(create_session).create_order(
+        "ethtwd",
+        "buy",
+        "0.2658",
+        price="21499.0",
+        ord_type="limit",
+        client_oid="client-1",
+    )
+
+    assert created.id == 87
+    assert create_session.calls[-1]["method"] == "POST"
+    assert create_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/order"
+    assert last_kwargs(create_session)["json"] == {
+        "market": "ethtwd",
+        "side": "buy",
+        "volume": "0.2658",
+        "price": "21499.0",
+        "client_oid": "client-1",
+        "ord_type": "limit",
+    }
+    assert last_payload(create_session)["path"] == "/api/v3/wallet/spot/order"
+
+    cancel_session = FakeSession(order_payload(state="cancel"))
+    assert authenticated_client(cancel_session).cancel_order(order_id=87).state == "cancel"
+    assert cancel_session.calls[-1]["method"] == "DELETE"
+    assert cancel_session.calls[-1]["url"] == "https://example.test/api/v3/order"
+    assert last_kwargs(cancel_session)["json"] == {"id": 87}
+
+    cancel_all_session = FakeSession([order_payload(state="cancel")])
+    cancelled = authenticated_client(cancel_all_session).cancel_orders(market="ethtwd", side="buy")
+    assert cancelled[0].state == "cancel"
+    assert cancel_all_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/orders"
+    assert last_kwargs(cancel_all_session)["json"] == {"market": "ethtwd", "side": "buy"}


### PR DESCRIPTION
## Summary
- Add v3 private account, order, cancel, and order-trade client wrappers
- Add Account, Order, and PrivateTrade models and exports
- Add mocked tests for authenticated private endpoint request construction and parsing
- Mark Phase 3 complete in PLAN.md

## Tests
- uv run ruff check .
- uv run ty check .
- uv run pytest -v -s --cov=src --cov-report=xml tests