### PR TITLE
feat(v3): add transaction and wallet fund endpoints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -62,22 +62,22 @@ The main missing areas are **REST API v3 transaction, wallet funds, convert, and
 
 ## Phase 4: REST v3 Transaction and Wallet Funds
 
-- [ ] `GET /api/v3/withdrawal`: withdrawal detail.
-- [ ] `POST /api/v3/withdrawal`: crypto withdrawal.
-- [ ] `POST /api/v3/withdrawal/twd`: TWD withdrawal.
-- [ ] `GET /api/v3/withdrawals`: withdrawal list.
-- [ ] `GET /api/v3/withdraw_addresses`: withdraw addresses.
-- [ ] `GET /api/v3/deposit`: deposit detail.
-- [ ] `GET /api/v3/deposits`: deposit list.
-- [ ] `GET /api/v3/deposit_address`: deposit address by currency/version.
-- [ ] `GET /api/v3/internal_transfers`: internal transfers.
-- [ ] `GET /api/v3/rewards`: rewards.
-- [ ] `GET /api/v3/fund_transactions/deposits`.
-- [ ] `GET /api/v3/fund_transactions/deposit`.
-- [ ] `GET /api/v3/fund_transactions/withdrawals`.
-- [ ] `GET /api/v3/fund_transactions/withdrawal`.
-- [ ] `GET /api/v3/fund_transactions/transfers`.
-- [ ] `GET /api/v3/fund_transactions/transfer`.
+- [x] `GET /api/v3/withdrawal`: withdrawal detail.
+- [x] `POST /api/v3/withdrawal`: crypto withdrawal.
+- [x] `POST /api/v3/withdrawal/twd`: TWD withdrawal.
+- [x] `GET /api/v3/withdrawals`: withdrawal list.
+- [x] `GET /api/v3/withdraw_addresses`: withdraw addresses.
+- [x] `GET /api/v3/deposit`: deposit detail.
+- [x] `GET /api/v3/deposits`: deposit list.
+- [x] `GET /api/v3/deposit_address`: deposit address by currency/version.
+- [x] `GET /api/v3/internal_transfers`: internal transfers.
+- [x] `GET /api/v3/rewards`: rewards.
+- [x] `GET /api/v3/fund_transactions/deposits`.
+- [x] `GET /api/v3/fund_transactions/deposit`.
+- [x] `GET /api/v3/fund_transactions/withdrawals`.
+- [x] `GET /api/v3/fund_transactions/withdrawal`.
+- [x] `GET /api/v3/fund_transactions/transfers`.
+- [x] `GET /api/v3/fund_transactions/transfer`.
 
 ## Phase 5: REST v3 Convert
 

--- a/src/maicoin/v3/__init__.py
+++ b/src/maicoin/v3/__init__.py
@@ -10,9 +10,16 @@ from maicoin.v3.errors import MaxHTTPError
 from maicoin.v3.models import Account
 from maicoin.v3.models import Currency
 from maicoin.v3.models import CurrencyNetwork
+from maicoin.v3.models import Deposit
+from maicoin.v3.models import DepositAddress
 from maicoin.v3.models import Depth
+from maicoin.v3.models import FundTransactionDeposit
+from maicoin.v3.models import FundTransactionSource
+from maicoin.v3.models import FundTransactionTransfer
+from maicoin.v3.models import FundTransactionWithdrawal
 from maicoin.v3.models import HistoricalIndexPrice
 from maicoin.v3.models import InterestRate
+from maicoin.v3.models import InternalTransfer
 from maicoin.v3.models import KLine
 from maicoin.v3.models import Market
 from maicoin.v3.models import Order
@@ -21,11 +28,14 @@ from maicoin.v3.models import OrderState
 from maicoin.v3.models import OrderType
 from maicoin.v3.models import PrivateTrade
 from maicoin.v3.models import PublicTrade
+from maicoin.v3.models import Reward
 from maicoin.v3.models import Staking
 from maicoin.v3.models import Ticker
 from maicoin.v3.models import Timestamp
 from maicoin.v3.models import UserInfo
 from maicoin.v3.models import VipLevel
+from maicoin.v3.models import WithdrawAddress
+from maicoin.v3.models import Withdrawal
 
 __all__ = [
     "BASE_URL",
@@ -34,9 +44,16 @@ __all__ = [
     "Client",
     "Currency",
     "CurrencyNetwork",
+    "Deposit",
+    "DepositAddress",
     "Depth",
+    "FundTransactionDeposit",
+    "FundTransactionSource",
+    "FundTransactionTransfer",
+    "FundTransactionWithdrawal",
     "HistoricalIndexPrice",
     "InterestRate",
+    "InternalTransfer",
     "KLine",
     "Market",
     "MaxAPIError",
@@ -47,11 +64,14 @@ __all__ = [
     "OrderType",
     "PrivateTrade",
     "PublicTrade",
+    "Reward",
     "Staking",
     "Ticker",
     "Timestamp",
     "UserInfo",
     "VipLevel",
+    "WithdrawAddress",
+    "Withdrawal",
     "build_auth_headers",
     "encode_payload",
     "generate_nonce",

--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -16,9 +16,15 @@ from maicoin.v3.errors import raise_for_api_error
 from maicoin.v3.errors import raise_for_response_status
 from maicoin.v3.models import Account
 from maicoin.v3.models import Currency
+from maicoin.v3.models import Deposit
+from maicoin.v3.models import DepositAddress
 from maicoin.v3.models import Depth
+from maicoin.v3.models import FundTransactionDeposit
+from maicoin.v3.models import FundTransactionTransfer
+from maicoin.v3.models import FundTransactionWithdrawal
 from maicoin.v3.models import HistoricalIndexPrice
 from maicoin.v3.models import InterestRate
+from maicoin.v3.models import InternalTransfer
 from maicoin.v3.models import KLine
 from maicoin.v3.models import Market
 from maicoin.v3.models import Order
@@ -26,9 +32,12 @@ from maicoin.v3.models import OrderSide
 from maicoin.v3.models import OrderType
 from maicoin.v3.models import PrivateTrade
 from maicoin.v3.models import PublicTrade
+from maicoin.v3.models import Reward
 from maicoin.v3.models import Ticker
 from maicoin.v3.models import Timestamp
 from maicoin.v3.models import UserInfo
+from maicoin.v3.models import WithdrawAddress
+from maicoin.v3.models import Withdrawal
 
 BASE_URL = "https://max-api.maicoin.com"
 DEFAULT_TIMEOUT = 10
@@ -324,6 +333,175 @@ class Client:
             auth=True,
         )
         return [PrivateTrade.model_validate(item) for item in cast("list[object]", payload)]
+
+    def withdrawal(self, uuid: str) -> Withdrawal:
+        payload = self.request("GET", "/api/v3/withdrawal", params={"uuid": uuid}, auth=True)
+        return Withdrawal.model_validate(payload)
+
+    def create_withdrawal(self, *, withdraw_address_uuid: str, amount: str) -> Withdrawal:
+        payload = self.request(
+            "POST",
+            "/api/v3/withdrawal",
+            params={"withdraw_address_uuid": withdraw_address_uuid, "amount": amount},
+            auth=True,
+        )
+        return Withdrawal.model_validate(payload)
+
+    def create_twd_withdrawal(self, amount: str) -> Withdrawal:
+        payload = self.request("POST", "/api/v3/withdrawal/twd", params={"amount": amount}, auth=True)
+        return Withdrawal.model_validate(payload)
+
+    def withdrawals(
+        self,
+        *,
+        currency: str | None = None,
+        state: str | None = None,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[Withdrawal]:
+        payload = self.request(
+            "GET",
+            "/api/v3/withdrawals",
+            params=_compact(
+                {"currency": currency, "state": state, "timestamp": timestamp, "order": order, "limit": limit}
+            ),
+            auth=True,
+        )
+        return [Withdrawal.model_validate(item) for item in cast("list[object]", payload)]
+
+    def withdraw_addresses(
+        self,
+        currency: str,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[WithdrawAddress]:
+        payload = self.request(
+            "GET",
+            "/api/v3/withdraw_addresses",
+            params=_compact({"currency": currency, "limit": limit, "offset": offset}),
+            auth=True,
+        )
+        return [WithdrawAddress.model_validate(item) for item in cast("list[object]", payload)]
+
+    def deposit(self, *, txid: str | None = None, uuid: str | None = None) -> Deposit:
+        payload = self.request("GET", "/api/v3/deposit", params=_compact({"txid": txid, "uuid": uuid}), auth=True)
+        return Deposit.model_validate(payload)
+
+    def deposits(
+        self,
+        *,
+        currency: str | None = None,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[Deposit]:
+        payload = self.request(
+            "GET",
+            "/api/v3/deposits",
+            params=_compact({"currency": currency, "timestamp": timestamp, "order": order, "limit": limit}),
+            auth=True,
+        )
+        return [Deposit.model_validate(item) for item in cast("list[object]", payload)]
+
+    def deposit_address(self, currency_version: str) -> DepositAddress:
+        payload = self.request(
+            "GET",
+            "/api/v3/deposit_address",
+            params={"currency_version": currency_version},
+            auth=True,
+        )
+        return DepositAddress.model_validate(payload)
+
+    def internal_transfers(
+        self,
+        side: str,
+        *,
+        currency: str | None = None,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[InternalTransfer]:
+        payload = self.request(
+            "GET",
+            "/api/v3/internal_transfers",
+            params=_compact(
+                {"side": side, "currency": currency, "timestamp": timestamp, "order": order, "limit": limit}
+            ),
+            auth=True,
+        )
+        return [InternalTransfer.model_validate(item) for item in cast("list[object]", payload)]
+
+    def rewards(
+        self,
+        *,
+        reward_type: str | None = None,
+        currency: str | None = None,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[Reward]:
+        payload = self.request(
+            "GET",
+            "/api/v3/rewards",
+            params=_compact(
+                {
+                    "reward_type": reward_type,
+                    "currency": currency,
+                    "timestamp": timestamp,
+                    "order": order,
+                    "limit": limit,
+                }
+            ),
+            auth=True,
+        )
+        return [Reward.model_validate(item) for item in cast("list[object]", payload)]
+
+    def fund_transaction_deposits(
+        self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
+    ) -> list[FundTransactionDeposit]:
+        payload = self.request(
+            "GET",
+            "/api/v3/fund_transactions/deposits",
+            params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
+            auth=True,
+        )
+        return [FundTransactionDeposit.model_validate(item) for item in cast("list[object]", payload)]
+
+    def fund_transaction_deposit(self, sn: str) -> FundTransactionDeposit:
+        payload = self.request("GET", "/api/v3/fund_transactions/deposit", params={"sn": sn}, auth=True)
+        return FundTransactionDeposit.model_validate(payload)
+
+    def fund_transaction_withdrawals(
+        self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
+    ) -> list[FundTransactionWithdrawal]:
+        payload = self.request(
+            "GET",
+            "/api/v3/fund_transactions/withdrawals",
+            params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
+            auth=True,
+        )
+        return [FundTransactionWithdrawal.model_validate(item) for item in cast("list[object]", payload)]
+
+    def fund_transaction_withdrawal(self, sn: str) -> FundTransactionWithdrawal:
+        payload = self.request("GET", "/api/v3/fund_transactions/withdrawal", params={"sn": sn}, auth=True)
+        return FundTransactionWithdrawal.model_validate(payload)
+
+    def fund_transaction_transfers(
+        self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
+    ) -> list[FundTransactionTransfer]:
+        payload = self.request(
+            "GET",
+            "/api/v3/fund_transactions/transfers",
+            params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
+            auth=True,
+        )
+        return [FundTransactionTransfer.model_validate(item) for item in cast("list[object]", payload)]
+
+    def fund_transaction_transfer(self, sn: str) -> FundTransactionTransfer:
+        payload = self.request("GET", "/api/v3/fund_transactions/transfer", params={"sn": sn}, auth=True)
+        return FundTransactionTransfer.model_validate(payload)
 
     def m_wallet_index_prices(self) -> dict[str, str]:
         payload = self.request("GET", "/api/v3/wallet/m/index_prices")

--- a/src/maicoin/v3/models.py
+++ b/src/maicoin/v3/models.py
@@ -4,10 +4,11 @@ from enum import StrEnum
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import Field
 
 
 class MaxBaseModel(BaseModel):
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
 
 
 class Market(MaxBaseModel):
@@ -169,6 +170,117 @@ class UserInfo(MaxBaseModel):
     current_vip_level: VipLevel
     next_vip_level: VipLevel | None
     m_wallet_enabled: bool | None = None
+
+
+class Withdrawal(MaxBaseModel):
+    uuid: str
+    currency: str
+    network_protocol: str | None
+    amount: str
+    fee: str
+    fee_currency: str
+    to_address: str
+    label: str
+    txid: str | None
+    created_at: int
+    state: str
+    transaction_type: str
+
+
+class WithdrawAddress(MaxBaseModel):
+    uuid: str
+    currency: str
+    network_protocol: str | None
+    address: str
+    extra_label: str
+    created_at: int
+    activated_at: int | None
+    is_internal: bool
+    network_congested: bool
+
+
+class Deposit(MaxBaseModel):
+    uuid: str
+    currency: str
+    network_protocol: str
+    amount: str
+    to_address: str
+    txid: str
+    created_at: int
+    confirmations: int
+    state: str
+    state_reason: str
+
+
+class DepositAddress(MaxBaseModel):
+    currency: str
+    network_protocol: str
+    currency_version: str
+    address: str | None
+
+
+class InternalTransfer(MaxBaseModel):
+    uuid: str
+    currency: str
+    amount: str
+    created_at: int
+    from_: str = Field(validation_alias="from", serialization_alias="from")
+    to: str
+    state: str
+
+
+class Reward(MaxBaseModel):
+    uuid: str
+    currency: str
+    amount: str
+    created_at: int
+    type: str
+    note: str
+
+
+class FundTransactionDeposit(MaxBaseModel):
+    sn: str
+    is_internal: bool
+    currency: str
+    amount: str
+    state: str
+    created_at: int
+    network_protocol: str | None
+    to_address: str | None
+    txid: str | None
+    from_: str | None = Field(validation_alias="from", serialization_alias="from")
+
+
+class FundTransactionWithdrawal(MaxBaseModel):
+    sn: str
+    is_internal: bool
+    currency: str
+    amount: str
+    state: str
+    created_at: int
+    network_protocol: str | None
+    fee: str | None
+    fee_currency: str | None
+    to_address: str | None
+    label: str | None
+    txid: str | None
+    to: str | None
+
+
+class FundTransactionSource(MaxBaseModel):
+    platform: str
+    sn: object
+    wallet_type: str
+
+
+class FundTransactionTransfer(MaxBaseModel):
+    sn: str
+    currency: str
+    amount: str
+    state: str
+    created_at: int
+    from_: FundTransactionSource = Field(validation_alias="from", serialization_alias="from")
+    to: FundTransactionSource
 
 
 class Ticker(MaxBaseModel):

--- a/tests/v3/test_funds.py
+++ b/tests/v3/test_funds.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Mapping
+from typing import cast
+
+from maicoin.v3 import Client
+from maicoin.v3 import Deposit
+from maicoin.v3 import DepositAddress
+from maicoin.v3 import FundTransactionDeposit
+from maicoin.v3 import FundTransactionTransfer
+from maicoin.v3 import FundTransactionWithdrawal
+from maicoin.v3 import InternalTransfer
+from maicoin.v3 import Reward
+from maicoin.v3 import WithdrawAddress
+from maicoin.v3 import Withdrawal
+
+
+class FakeResponse:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+        self.status_code = 200
+        self.content = b"{}"
+        self.text = str(payload)
+
+    def json(self) -> object:
+        return self.payload
+
+
+class FakeSession:
+    def __init__(self, payload: object) -> None:
+        self.response = FakeResponse(payload)
+        self.calls: list[dict[str, object]] = []
+
+    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        return self.response
+
+
+def authenticated_client(session: FakeSession) -> Client:
+    return Client(
+        api_key="key",
+        api_secret="secret",
+        base_url="https://example.test",
+        session=session,
+        nonce_factory=lambda: 123456,
+    )
+
+
+def last_kwargs(session: FakeSession) -> Mapping[str, object]:
+    return cast("Mapping[str, object]", session.calls[-1]["kwargs"])
+
+
+def last_payload(session: FakeSession) -> Mapping[str, object]:
+    headers = cast("Mapping[str, str]", last_kwargs(session)["headers"])
+    payload = base64.b64decode(headers["X-MAX-PAYLOAD"]).decode()
+    return cast("Mapping[str, object]", json.loads(payload))
+
+
+def withdrawal_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "uuid": "18022603540001",
+        "currency": "usdt",
+        "network_protocol": "tron-trc20",
+        "amount": "0.019",
+        "fee": "0.0",
+        "fee_currency": "usdt",
+        "to_address": "TU91BoeyrqW9MKaiRPDiE6z7UecK2n2Hze",
+        "label": "My Web3 Wallet",
+        "txid": None,
+        "created_at": 1521726960357,
+        "state": "processing",
+        "transaction_type": "external",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def deposit_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "uuid": "18022603540001",
+        "currency": "usdt",
+        "network_protocol": "ethereum-erc20",
+        "amount": "0.019",
+        "to_address": "0x5c7d23d516f120d322fc7b116386b7e491739138",
+        "txid": "0x8daa98e07886985bd6a142cd81b83582d6085f7eb931dc4984c18c84f2a845e0",
+        "created_at": 1521726960357,
+        "confirmations": 64,
+        "state": "done",
+        "state_reason": "",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def fund_deposit_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "sn": "18022603540001",
+        "is_internal": False,
+        "currency": "usdt",
+        "amount": "0.019",
+        "state": "done",
+        "created_at": 1521726960123,
+        "network_protocol": "ethereum-erc20",
+        "to_address": "0x5c7d23d516f120d322fc7b116386b7e491739138",
+        "txid": "0x8daa98e07886985bd6a142cd81b83582d6085f7eb931dc4984c18c84f2a845e0",
+        "from": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def fund_withdrawal_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "sn": "18022603540001",
+        "is_internal": False,
+        "currency": "usdt",
+        "amount": "0.019",
+        "state": "processing",
+        "created_at": 1521726960123,
+        "network_protocol": "tron-trc20",
+        "fee": "0.0",
+        "fee_currency": "usdt",
+        "to_address": "TU91BoeyrqW9MKaiRPDiE6z7UecK2n2Hze",
+        "label": "My Web3 Wallet",
+        "txid": None,
+        "to": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def fund_transfer_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "sn": "18022603540001",
+        "currency": "usdt",
+        "amount": "0.019",
+        "state": "done",
+        "created_at": 1521726960123,
+        "from": {"platform": "max", "sn": "src-1", "wallet_type": "spot"},
+        "to": {"platform": "max", "sn": "dst-1", "wallet_type": "m"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_withdrawal_methods_construct_authenticated_requests_and_parse_payloads() -> None:
+    detail_session = FakeSession(withdrawal_payload())
+    withdrawal = authenticated_client(detail_session).withdrawal("18022603540001")
+
+    assert withdrawal == Withdrawal.model_validate(withdrawal_payload())
+    assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/withdrawal"
+    assert last_kwargs(detail_session)["params"] == {"uuid": "18022603540001"}
+
+    create_session = FakeSession(withdrawal_payload())
+    authenticated_client(create_session).create_withdrawal(withdraw_address_uuid="addr-1", amount="0.019")
+    assert create_session.calls[-1]["method"] == "POST"
+    assert last_kwargs(create_session)["json"] == {"withdraw_address_uuid": "addr-1", "amount": "0.019"}
+    assert last_payload(create_session)["path"] == "/api/v3/withdrawal"
+
+    twd_session = FakeSession(withdrawal_payload(currency="twd", network_protocol=None, amount="100"))
+    authenticated_client(twd_session).create_twd_withdrawal("100")
+    assert twd_session.calls[-1]["url"] == "https://example.test/api/v3/withdrawal/twd"
+    assert last_kwargs(twd_session)["json"] == {"amount": "100"}
+
+
+def test_withdrawals_and_withdraw_addresses_parse_lists() -> None:
+    withdrawals_session = FakeSession([withdrawal_payload()])
+    withdrawals = authenticated_client(withdrawals_session).withdrawals(currency="usdt", state="done", limit=1)
+
+    assert withdrawals == [Withdrawal.model_validate(withdrawal_payload())]
+    assert withdrawals_session.calls[-1]["url"] == "https://example.test/api/v3/withdrawals"
+    assert last_kwargs(withdrawals_session)["params"] == {"currency": "usdt", "state": "done", "limit": 1}
+
+    address_payload = {
+        "uuid": "508c9af6-ccc1-4122-b38f-a407e3bac96c",
+        "currency": "usdt",
+        "network_protocol": "tron-trc20",
+        "address": "TU91BoeyrqW9MKaiRPDiE6z7UecK2n2Hze",
+        "extra_label": "My Max Wallet",
+        "created_at": 1521726960357,
+        "activated_at": None,
+        "is_internal": True,
+        "network_congested": False,
+    }
+    address_session = FakeSession([address_payload])
+    addresses = authenticated_client(address_session).withdraw_addresses("usdt", limit=10, offset=20)
+
+    assert addresses == [WithdrawAddress.model_validate(address_payload)]
+    assert address_session.calls[-1]["url"] == "https://example.test/api/v3/withdraw_addresses"
+    assert last_kwargs(address_session)["params"] == {"currency": "usdt", "limit": 10, "offset": 20}
+
+
+def test_deposit_methods_construct_authenticated_requests_and_parse_payloads() -> None:
+    detail_session = FakeSession(deposit_payload())
+    deposit = authenticated_client(detail_session).deposit(uuid="18022603540001")
+
+    assert deposit == Deposit.model_validate(deposit_payload())
+    assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/deposit"
+    assert last_kwargs(detail_session)["params"] == {"uuid": "18022603540001"}
+
+    deposits_session = FakeSession([deposit_payload()])
+    deposits = authenticated_client(deposits_session).deposits(currency="usdt", order="asc", limit=1)
+    assert deposits == [Deposit.model_validate(deposit_payload())]
+    assert last_kwargs(deposits_session)["params"] == {"currency": "usdt", "order": "asc", "limit": 1}
+
+    address_payload = {
+        "currency": "usdt",
+        "network_protocol": "tron-trc20",
+        "currency_version": "trc20usdt",
+        "address": "TU91BoeyrqW9MKaiRPDiE6z7UecK2n2Hze",
+    }
+    address_session = FakeSession(address_payload)
+    address = authenticated_client(address_session).deposit_address("trc20usdt")
+    assert address == DepositAddress.model_validate(address_payload)
+    assert address_session.calls[-1]["url"] == "https://example.test/api/v3/deposit_address"
+    assert last_kwargs(address_session)["params"] == {"currency_version": "trc20usdt"}
+
+
+def test_internal_transfers_and_rewards_construct_requests_and_parse_payloads() -> None:
+    transfer_payload = {
+        "uuid": "18032011380001",
+        "currency": "eth",
+        "amount": "0.019",
+        "created_at": 1521726960357,
+        "from": "pr***@***.com",
+        "to": "member@maicoin.com",
+        "state": "done",
+    }
+    transfer_session = FakeSession([transfer_payload])
+    transfers = authenticated_client(transfer_session).internal_transfers("in", currency="eth", limit=1)
+
+    assert transfers == [InternalTransfer.model_validate(transfer_payload)]
+    assert transfers[0].from_ == "pr***@***.com"
+    assert last_kwargs(transfer_session)["params"] == {"side": "in", "currency": "eth", "limit": 1}
+
+    reward_payload = {
+        "uuid": "18032011380001",
+        "currency": "eth",
+        "amount": "0.019",
+        "created_at": 1521726960357,
+        "type": "airdrop_reward",
+        "note": "2018-11-13 Holding Reward",
+    }
+    reward_session = FakeSession([reward_payload])
+    rewards = authenticated_client(reward_session).rewards(reward_type="airdrop_reward", limit=1)
+
+    assert rewards == [Reward.model_validate(reward_payload)]
+    assert reward_session.calls[-1]["url"] == "https://example.test/api/v3/rewards"
+    assert last_kwargs(reward_session)["params"] == {"reward_type": "airdrop_reward", "limit": 1}
+
+
+def test_fund_transaction_deposit_methods_parse_list_and_detail() -> None:
+    list_session = FakeSession([fund_deposit_payload()])
+    deposits = authenticated_client(list_session).fund_transaction_deposits(
+        timestamp=1521726960123, order="desc", limit=1
+    )
+
+    assert deposits == [FundTransactionDeposit.model_validate(fund_deposit_payload())]
+    assert deposits[0].from_ is None
+    assert list_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/deposits"
+    assert last_kwargs(list_session)["params"] == {"timestamp": 1521726960123, "order": "desc", "limit": 1}
+
+    detail_session = FakeSession(fund_deposit_payload())
+    assert authenticated_client(detail_session).fund_transaction_deposit("18022603540001").sn == "18022603540001"
+    assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/deposit"
+    assert last_kwargs(detail_session)["params"] == {"sn": "18022603540001"}
+
+
+def test_fund_transaction_withdrawal_methods_parse_list_and_detail() -> None:
+    list_session = FakeSession([fund_withdrawal_payload()])
+    withdrawals = authenticated_client(list_session).fund_transaction_withdrawals(limit=1)
+
+    assert withdrawals == [FundTransactionWithdrawal.model_validate(fund_withdrawal_payload())]
+    assert list_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/withdrawals"
+    assert last_kwargs(list_session)["params"] == {"limit": 1}
+
+    detail_session = FakeSession(fund_withdrawal_payload())
+    assert authenticated_client(detail_session).fund_transaction_withdrawal("18022603540001").sn == "18022603540001"
+    assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/withdrawal"
+    assert last_kwargs(detail_session)["params"] == {"sn": "18022603540001"}
+
+
+def test_fund_transaction_transfer_methods_parse_list_and_detail() -> None:
+    list_session = FakeSession([fund_transfer_payload()])
+    transfers = authenticated_client(list_session).fund_transaction_transfers(limit=1)
+
+    assert transfers == [FundTransactionTransfer.model_validate(fund_transfer_payload())]
+    assert transfers[0].from_.wallet_type == "spot"
+    assert list_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/transfers"
+    assert last_kwargs(list_session)["params"] == {"limit": 1}
+
+    detail_session = FakeSession(fund_transfer_payload())
+    assert authenticated_client(detail_session).fund_transaction_transfer("18022603540001").sn == "18022603540001"
+    assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/transfer"
+    assert last_kwargs(detail_session)["params"] == {"sn": "18022603540001"}


### PR DESCRIPTION
## Summary
- add REST v3 withdrawal, deposit, internal transfer, reward, and fund transaction wrappers
- add typed models for transaction and wallet fund responses
- cover request construction and parsing with mocked tests only
- mark Phase 4 complete in TODO

## Tests
- just