### PR TITLE
feat(v3): add convert endpoints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -81,11 +81,11 @@ The main missing areas are **REST API v3 transaction, wallet funds, convert, and
 
 ## Phase 5: REST v3 Convert
 
-- [ ] `POST /api/v3/convert`: create convert.
-- [ ] `GET /api/v3/convert`: convert detail.
-- [ ] `GET /api/v3/converts`: convert list.
-- [ ] Add convert request/response models.
-- [ ] Add mocked tests.
+- [x] `POST /api/v3/convert`: create convert.
+- [x] `GET /api/v3/convert`: convert detail.
+- [x] `GET /api/v3/converts`: convert list.
+- [x] Add convert request/response models.
+- [x] Add mocked tests.
 
 ## Phase 6: REST v3 M-Wallet Private Endpoints
 

--- a/src/maicoin/v3/__init__.py
+++ b/src/maicoin/v3/__init__.py
@@ -8,6 +8,7 @@ from maicoin.v3.client import Client
 from maicoin.v3.errors import MaxAPIError
 from maicoin.v3.errors import MaxHTTPError
 from maicoin.v3.models import Account
+from maicoin.v3.models import ConvertOrder
 from maicoin.v3.models import Currency
 from maicoin.v3.models import CurrencyNetwork
 from maicoin.v3.models import Deposit
@@ -42,6 +43,7 @@ __all__ = [
     "DEFAULT_TIMEOUT",
     "Account",
     "Client",
+    "ConvertOrder",
     "Currency",
     "CurrencyNetwork",
     "Deposit",

--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -15,6 +15,7 @@ from maicoin.v3.errors import Response
 from maicoin.v3.errors import raise_for_api_error
 from maicoin.v3.errors import raise_for_response_status
 from maicoin.v3.models import Account
+from maicoin.v3.models import ConvertOrder
 from maicoin.v3.models import Currency
 from maicoin.v3.models import Deposit
 from maicoin.v3.models import DepositAddress
@@ -502,6 +503,44 @@ class Client:
     def fund_transaction_transfer(self, sn: str) -> FundTransactionTransfer:
         payload = self.request("GET", "/api/v3/fund_transactions/transfer", params={"sn": sn}, auth=True)
         return FundTransactionTransfer.model_validate(payload)
+
+    def create_convert(
+        self,
+        *,
+        from_currency: str,
+        to_currency: str,
+        from_amount: str | None = None,
+        to_amount: str | None = None,
+    ) -> ConvertOrder:
+        payload = self.request(
+            "POST",
+            "/api/v3/convert",
+            params=_compact(
+                {
+                    "from_currency": from_currency,
+                    "to_currency": to_currency,
+                    "from_amount": from_amount,
+                    "to_amount": to_amount,
+                }
+            ),
+            auth=True,
+        )
+        return ConvertOrder.model_validate(payload)
+
+    def convert(self, sn: str) -> ConvertOrder:
+        payload = self.request("GET", "/api/v3/convert", params={"sn": sn}, auth=True)
+        return ConvertOrder.model_validate(payload)
+
+    def converts(
+        self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
+    ) -> list[ConvertOrder]:
+        payload = self.request(
+            "GET",
+            "/api/v3/converts",
+            params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
+            auth=True,
+        )
+        return [ConvertOrder.model_validate(item) for item in cast("list[object]", payload)]
 
     def m_wallet_index_prices(self) -> dict[str, str]:
         payload = self.request("GET", "/api/v3/wallet/m/index_prices")

--- a/src/maicoin/v3/models.py
+++ b/src/maicoin/v3/models.py
@@ -283,6 +283,18 @@ class FundTransactionTransfer(MaxBaseModel):
     to: FundTransactionSource
 
 
+class ConvertOrder(MaxBaseModel):
+    sn: str
+    from_currency: str
+    from_amount: str
+    to_currency: str
+    to_amount: str
+    fee: str
+    fee_currency: str
+    fee_in_twd: str
+    created_at: int
+
+
 class Ticker(MaxBaseModel):
     market: str
     at: int

--- a/tests/v3/test_convert.py
+++ b/tests/v3/test_convert.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Mapping
+from typing import cast
+
+from maicoin.v3 import Client
+from maicoin.v3 import ConvertOrder
+
+
+class FakeResponse:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+        self.status_code = 200
+        self.content = b"{}"
+        self.text = str(payload)
+
+    def json(self) -> object:
+        return self.payload
+
+
+class FakeSession:
+    def __init__(self, payload: object) -> None:
+        self.response = FakeResponse(payload)
+        self.calls: list[dict[str, object]] = []
+
+    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        return self.response
+
+
+def authenticated_client(session: FakeSession) -> Client:
+    return Client(
+        api_key="key",
+        api_secret="secret",
+        base_url="https://example.test",
+        session=session,
+        nonce_factory=lambda: 123456,
+    )
+
+
+def last_kwargs(session: FakeSession) -> Mapping[str, object]:
+    return cast("Mapping[str, object]", session.calls[-1]["kwargs"])
+
+
+def last_payload(session: FakeSession) -> Mapping[str, object]:
+    headers = cast("Mapping[str, str]", last_kwargs(session)["headers"])
+    payload = base64.b64decode(headers["X-MAX-PAYLOAD"]).decode()
+    return cast("Mapping[str, object]", json.loads(payload))
+
+
+def convert_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "sn": "6322d9bd-736b-4f19-b862-829e75cae1ce",
+        "from_currency": "btc",
+        "from_amount": "0.01",
+        "to_currency": "usdt",
+        "to_amount": "289.13",
+        "fee": "0.87",
+        "fee_currency": "usdt",
+        "fee_in_twd": "0.31",
+        "created_at": 1704937708,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_create_convert_constructs_authenticated_post_and_parses_payload() -> None:
+    session = FakeSession(convert_payload())
+    convert = authenticated_client(session).create_convert(
+        from_currency="btc",
+        to_currency="usdt",
+        from_amount="0.01",
+    )
+
+    assert convert == ConvertOrder.model_validate(convert_payload())
+    assert session.calls[-1]["method"] == "POST"
+    assert session.calls[-1]["url"] == "https://example.test/api/v3/convert"
+    assert last_kwargs(session)["json"] == {
+        "from_currency": "btc",
+        "to_currency": "usdt",
+        "from_amount": "0.01",
+    }
+    assert last_payload(session)["path"] == "/api/v3/convert"
+
+
+def test_convert_detail_constructs_authenticated_get_and_parses_payload() -> None:
+    session = FakeSession(convert_payload())
+    convert = authenticated_client(session).convert("6322d9bd-736b-4f19-b862-829e75cae1ce")
+
+    assert convert.sn == "6322d9bd-736b-4f19-b862-829e75cae1ce"
+    assert session.calls[-1]["method"] == "GET"
+    assert session.calls[-1]["url"] == "https://example.test/api/v3/convert"
+    assert last_kwargs(session)["params"] == {"sn": "6322d9bd-736b-4f19-b862-829e75cae1ce"}
+
+
+def test_converts_constructs_authenticated_get_and_parses_list() -> None:
+    session = FakeSession([convert_payload()])
+    converts = authenticated_client(session).converts(timestamp=1704937708, order="desc", limit=1)
+
+    assert converts == [ConvertOrder.model_validate(convert_payload())]
+    assert session.calls[-1]["method"] == "GET"
+    assert session.calls[-1]["url"] == "https://example.test/api/v3/converts"
+    assert last_kwargs(session)["params"] == {"timestamp": 1704937708, "order": "desc", "limit": 1}


### PR DESCRIPTION
## Summary
- add REST v3 convert order model and client wrappers
- cover create, detail, and list convert endpoints with mocked tests
- mark Phase 5 REST v3 Convert as complete

## Tests
- uv run ruff check .
- uv run ty check .
- uv run pytest -v -s --cov=src --cov-report=xml tests