### PR TITLE
Add REST v3 M-Wallet private endpoints

### DIFF
--- a/src/maicoin/v3/__init__.py
+++ b/src/maicoin/v3/__init__.py
@@ -23,6 +23,15 @@ from maicoin.v3.models import InterestRate
 from maicoin.v3.models import InternalTransfer
 from maicoin.v3.models import KLine
 from maicoin.v3.models import Market
+from maicoin.v3.models import MWalletADRatio
+from maicoin.v3.models import MWalletForcedLiquidation
+from maicoin.v3.models import MWalletInterest
+from maicoin.v3.models import MWalletLiquidation
+from maicoin.v3.models import MWalletLiquidationDetail
+from maicoin.v3.models import MWalletLiquidationRepayment
+from maicoin.v3.models import MWalletLoan
+from maicoin.v3.models import MWalletRepayment
+from maicoin.v3.models import MWalletTransfer
 from maicoin.v3.models import Order
 from maicoin.v3.models import OrderSide
 from maicoin.v3.models import OrderState
@@ -57,6 +66,15 @@ __all__ = [
     "InterestRate",
     "InternalTransfer",
     "KLine",
+    "MWalletADRatio",
+    "MWalletForcedLiquidation",
+    "MWalletInterest",
+    "MWalletLiquidation",
+    "MWalletLiquidationDetail",
+    "MWalletLiquidationRepayment",
+    "MWalletLoan",
+    "MWalletRepayment",
+    "MWalletTransfer",
     "Market",
     "MaxAPIError",
     "MaxHTTPError",

--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -28,6 +28,13 @@ from maicoin.v3.models import InterestRate
 from maicoin.v3.models import InternalTransfer
 from maicoin.v3.models import KLine
 from maicoin.v3.models import Market
+from maicoin.v3.models import MWalletADRatio
+from maicoin.v3.models import MWalletInterest
+from maicoin.v3.models import MWalletLiquidation
+from maicoin.v3.models import MWalletLiquidationDetail
+from maicoin.v3.models import MWalletLoan
+from maicoin.v3.models import MWalletRepayment
+from maicoin.v3.models import MWalletTransfer
 from maicoin.v3.models import Order
 from maicoin.v3.models import OrderSide
 from maicoin.v3.models import OrderType
@@ -569,3 +576,116 @@ class Client:
         return {
             currency: InterestRate.model_validate(rate) for currency, rate in cast("dict[str, object]", payload).items()
         }
+
+    def create_m_wallet_loan(self, *, currency: str, amount: str) -> MWalletLoan:
+        payload = self.request(
+            "POST",
+            "/api/v3/wallet/m/loan",
+            params={"currency": currency, "amount": amount},
+            auth=True,
+        )
+        return MWalletLoan.model_validate(payload)
+
+    def m_wallet_loans(
+        self,
+        currency: str,
+        *,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[MWalletLoan]:
+        payload = self.request(
+            "GET",
+            "/api/v3/wallet/m/loans",
+            params=_compact({"currency": currency, "timestamp": timestamp, "order": order, "limit": limit}),
+            auth=True,
+        )
+        return [MWalletLoan.model_validate(item) for item in cast("list[object]", payload)]
+
+    def create_m_wallet_transfer(self, *, currency: str, amount: str, side: str) -> MWalletTransfer:
+        payload = self.request(
+            "POST",
+            "/api/v3/wallet/m/transfer",
+            params={"currency": currency, "amount": amount, "side": side},
+            auth=True,
+        )
+        return MWalletTransfer.model_validate(payload)
+
+    def m_wallet_transfers(
+        self,
+        *,
+        currency: str,
+        side: str,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[MWalletTransfer]:
+        payload = self.request(
+            "GET",
+            "/api/v3/wallet/m/transfers",
+            params=_compact(
+                {"currency": currency, "side": side, "timestamp": timestamp, "order": order, "limit": limit}
+            ),
+            auth=True,
+        )
+        return [MWalletTransfer.model_validate(item) for item in cast("list[object]", payload)]
+
+    def create_m_wallet_repayment(self, *, currency: str, amount: str) -> MWalletRepayment:
+        payload = self.request(
+            "POST",
+            "/api/v3/wallet/m/repayment",
+            params={"currency": currency, "amount": amount},
+            auth=True,
+        )
+        return MWalletRepayment.model_validate(payload)
+
+    def m_wallet_repayments(
+        self,
+        currency: str,
+        *,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[MWalletRepayment]:
+        payload = self.request(
+            "GET",
+            "/api/v3/wallet/m/repayments",
+            params=_compact({"currency": currency, "timestamp": timestamp, "order": order, "limit": limit}),
+            auth=True,
+        )
+        return [MWalletRepayment.model_validate(item) for item in cast("list[object]", payload)]
+
+    def m_wallet_liquidations(
+        self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
+    ) -> list[MWalletLiquidation]:
+        payload = self.request(
+            "GET",
+            "/api/v3/wallet/m/liquidations",
+            params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
+            auth=True,
+        )
+        return [MWalletLiquidation.model_validate(item) for item in cast("list[object]", payload)]
+
+    def m_wallet_liquidation(self, sn: str) -> MWalletLiquidationDetail:
+        payload = self.request("GET", "/api/v3/wallet/m/liquidation", params={"sn": sn}, auth=True)
+        return MWalletLiquidationDetail.model_validate(payload)
+
+    def m_wallet_interests(
+        self,
+        *,
+        currency: str | None = None,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[MWalletInterest]:
+        payload = self.request(
+            "GET",
+            "/api/v3/wallet/m/interests",
+            params=_compact({"currency": currency, "timestamp": timestamp, "order": order, "limit": limit}),
+            auth=True,
+        )
+        return [MWalletInterest.model_validate(item) for item in cast("list[object]", payload)]
+
+    def m_wallet_ad_ratio(self) -> MWalletADRatio:
+        payload = self.request("GET", "/api/v3/wallet/m/ad_ratio", auth=True)
+        return MWalletADRatio.model_validate(payload)

--- a/src/maicoin/v3/models.py
+++ b/src/maicoin/v3/models.py
@@ -319,3 +319,76 @@ class HistoricalIndexPrice(MaxBaseModel):
 class InterestRate(MaxBaseModel):
     hourly_interest_rate: str
     next_hourly_interest_rate: str
+
+
+class MWalletLoan(MaxBaseModel):
+    sn: str
+    currency: str
+    amount: str
+    state: str
+    created_at: int
+    interest_rate: str
+
+
+class MWalletTransfer(MaxBaseModel):
+    sn: str
+    side: str
+    currency: str
+    amount: str
+    created_at: int
+    state: str
+
+
+class MWalletRepayment(MaxBaseModel):
+    currency: str
+    amount: str
+    principal: str
+    interest: str
+    state: str
+    sn: str
+    created_at: int
+
+
+class MWalletLiquidation(MaxBaseModel):
+    sn: str
+    ad_ratio: str
+    expected_ad_ratio: str
+    created_at: int
+    state: str
+
+
+class MWalletLiquidationRepayment(MaxBaseModel):
+    currency: str
+    amount: str
+    principal: str
+    interest: str
+    state: str
+
+
+class MWalletForcedLiquidation(MaxBaseModel):
+    market: str
+    type: str
+    price: str
+    volume: str
+    fee: str
+    fee_currency: str
+    repayment: MWalletLiquidationRepayment
+
+
+class MWalletLiquidationDetail(MWalletLiquidation):
+    repayments: list[MWalletLiquidationRepayment]
+    liquidations: list[MWalletForcedLiquidation]
+
+
+class MWalletInterest(MaxBaseModel):
+    currency: str
+    amount: str
+    interest_rate: str
+    principal: str
+    created_at: int
+
+
+class MWalletADRatio(MaxBaseModel):
+    ad_ratio: str
+    asset_in_usdt: str
+    debt_in_usdt: str

--- a/tests/v3/test_m_wallet_private.py
+++ b/tests/v3/test_m_wallet_private.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Mapping
+from typing import cast
+
+from maicoin.v3 import Client
+from maicoin.v3 import MWalletADRatio
+from maicoin.v3 import MWalletInterest
+from maicoin.v3 import MWalletLiquidation
+from maicoin.v3 import MWalletLiquidationDetail
+from maicoin.v3 import MWalletLoan
+from maicoin.v3 import MWalletRepayment
+from maicoin.v3 import MWalletTransfer
+
+
+class FakeResponse:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+        self.status_code = 200
+        self.content = b"{}"
+        self.text = str(payload)
+
+    def json(self) -> object:
+        return self.payload
+
+
+class FakeSession:
+    def __init__(self, payload: object) -> None:
+        self.response = FakeResponse(payload)
+        self.calls: list[dict[str, object]] = []
+
+    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        return self.response
+
+
+def authenticated_client(session: FakeSession) -> Client:
+    return Client(
+        api_key="key",
+        api_secret="secret",
+        base_url="https://example.test",
+        session=session,
+        nonce_factory=lambda: 123456,
+    )
+
+
+def last_kwargs(session: FakeSession) -> Mapping[str, object]:
+    return cast("Mapping[str, object]", session.calls[-1]["kwargs"])
+
+
+def last_payload(session: FakeSession) -> Mapping[str, object]:
+    headers = cast("Mapping[str, str]", last_kwargs(session)["headers"])
+    payload = base64.b64decode(headers["X-MAX-PAYLOAD"]).decode()
+    return cast("Mapping[str, object]", json.loads(payload))
+
+
+def loan_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "sn": "210407080800050666",
+        "currency": "eth",
+        "amount": "0.019",
+        "state": "confirmed",
+        "created_at": 1521726960357,
+        "interest_rate": "0.001",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def transfer_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "sn": "210407080800050666",
+        "side": "in",
+        "currency": "eth",
+        "amount": "0.019",
+        "created_at": 1521726960123,
+        "state": "processing",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def repayment_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "currency": "eth",
+        "amount": "0.15",
+        "principal": "0.1",
+        "interest": "0.05",
+        "state": "confirmed",
+        "sn": "210407080800050666",
+        "created_at": 1521726960123,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def liquidation_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "sn": "210407080800050666",
+        "ad_ratio": "1.2",
+        "expected_ad_ratio": "1.5",
+        "created_at": 1521726960357,
+        "state": "liquidated",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def liquidation_detail_payload() -> dict[str, object]:
+    repayment = {
+        "currency": "eth",
+        "amount": "0.15",
+        "principal": "0.1",
+        "interest": "0.05",
+        "state": "confirmed",
+    }
+    return liquidation_payload(
+        repayments=[repayment],
+        liquidations=[
+            {
+                "market": "ethusdt",
+                "type": "buy",
+                "price": "3200",
+                "volume": "0.1",
+                "fee": "0.001",
+                "fee_currency": "eth",
+                "repayment": repayment,
+            }
+        ],
+    )
+
+
+def test_create_m_wallet_loan_and_history_construct_authenticated_requests() -> None:
+    create_session = FakeSession(loan_payload())
+    loan = authenticated_client(create_session).create_m_wallet_loan(currency="eth", amount="0.019")
+
+    assert loan == MWalletLoan.model_validate(loan_payload())
+    assert create_session.calls[-1]["method"] == "POST"
+    assert create_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/loan"
+    assert last_kwargs(create_session)["json"] == {"currency": "eth", "amount": "0.019"}
+    assert last_payload(create_session)["path"] == "/api/v3/wallet/m/loan"
+
+    list_session = FakeSession([loan_payload()])
+    loans = authenticated_client(list_session).m_wallet_loans("eth", timestamp=1521726960357, order="desc", limit=1)
+    assert loans == [MWalletLoan.model_validate(loan_payload())]
+    assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/loans"
+    assert last_kwargs(list_session)["params"] == {
+        "currency": "eth",
+        "timestamp": 1521726960357,
+        "order": "desc",
+        "limit": 1,
+    }
+
+
+def test_m_wallet_transfer_create_and_history_construct_requests() -> None:
+    create_session = FakeSession(transfer_payload())
+    transfer = authenticated_client(create_session).create_m_wallet_transfer(currency="eth", amount="0.019", side="in")
+
+    assert transfer == MWalletTransfer.model_validate(transfer_payload())
+    assert create_session.calls[-1]["method"] == "POST"
+    assert create_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/transfer"
+    assert last_kwargs(create_session)["json"] == {"currency": "eth", "amount": "0.019", "side": "in"}
+
+    list_session = FakeSession([transfer_payload()])
+    transfers = authenticated_client(list_session).m_wallet_transfers(currency="eth", side="in", limit=1)
+    assert transfers == [MWalletTransfer.model_validate(transfer_payload())]
+    assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/transfers"
+    assert last_kwargs(list_session)["params"] == {"currency": "eth", "side": "in", "limit": 1}
+
+
+def test_m_wallet_repayment_create_and_history_construct_requests() -> None:
+    create_session = FakeSession(repayment_payload())
+    repayment = authenticated_client(create_session).create_m_wallet_repayment(currency="eth", amount="0.15")
+
+    assert repayment == MWalletRepayment.model_validate(repayment_payload())
+    assert create_session.calls[-1]["method"] == "POST"
+    assert create_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/repayment"
+    assert last_kwargs(create_session)["json"] == {"currency": "eth", "amount": "0.15"}
+
+    list_session = FakeSession([repayment_payload()])
+    repayments = authenticated_client(list_session).m_wallet_repayments("eth", order="asc", limit=1)
+    assert repayments == [MWalletRepayment.model_validate(repayment_payload())]
+    assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/repayments"
+    assert last_kwargs(list_session)["params"] == {"currency": "eth", "order": "asc", "limit": 1}
+
+
+def test_m_wallet_liquidations_and_detail_parse_nested_payloads() -> None:
+    list_session = FakeSession([liquidation_payload()])
+    liquidations = authenticated_client(list_session).m_wallet_liquidations(limit=1)
+
+    assert liquidations == [MWalletLiquidation.model_validate(liquidation_payload())]
+    assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/liquidations"
+    assert last_kwargs(list_session)["params"] == {"limit": 1}
+
+    detail_session = FakeSession(liquidation_detail_payload())
+    detail = authenticated_client(detail_session).m_wallet_liquidation("210407080800050666")
+    assert detail == MWalletLiquidationDetail.model_validate(liquidation_detail_payload())
+    assert detail.repayments[0].principal == "0.1"
+    assert detail.liquidations[0].repayment.interest == "0.05"
+    assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/liquidation"
+    assert last_kwargs(detail_session)["params"] == {"sn": "210407080800050666"}
+
+
+def test_m_wallet_interests_and_ad_ratio_construct_authenticated_requests() -> None:
+    interest_payload = {
+        "currency": "eth",
+        "amount": "0.003",
+        "interest_rate": "0.001",
+        "principal": "3",
+        "created_at": 1521726960123,
+    }
+    interests_session = FakeSession([interest_payload])
+    interests = authenticated_client(interests_session).m_wallet_interests(currency="eth", limit=1)
+
+    assert interests == [MWalletInterest.model_validate(interest_payload)]
+    assert interests_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/interests"
+    assert last_kwargs(interests_session)["params"] == {"currency": "eth", "limit": 1}
+
+    ad_ratio_payload = {"ad_ratio": "1.21", "asset_in_usdt": "2639.98128484", "debt_in_usdt": "2165.54482641"}
+    ad_ratio_session = FakeSession(ad_ratio_payload)
+    ad_ratio = authenticated_client(ad_ratio_session).m_wallet_ad_ratio()
+    assert ad_ratio == MWalletADRatio.model_validate(ad_ratio_payload)
+    assert ad_ratio_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/ad_ratio"
+    assert last_payload(ad_ratio_session) == {"nonce": 123456, "path": "/api/v3/wallet/m/ad_ratio"}


### PR DESCRIPTION
## Summary
- add typed models for M-Wallet private loan, transfer, repayment, liquidation, interest, and AD ratio payloads
- add authenticated REST v3 client methods for M-Wallet private endpoints
- cover request construction and model parsing with unit tests

## Tests
- just