### PR TITLE
feat(ws): close websocket gaps

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -102,13 +102,13 @@ The main missing areas are **REST API v3 transaction, wallet funds, convert, and
 
 ## Phase 7: WebSocket Gap Cleanup
 
-- [ ] Add public channel support for MWallet Pool Quota.
-- [ ] Add private channel support for Fast Trade.
-- [ ] Add MWallet private channels: order, trade, fast trade, account, AD ratio, and borrowing.
-- [ ] Add book response fields: `fi`, `li`, and `v`.
-- [ ] Add a `market_status` subscription test.
-- [ ] Check whether `Request.unsubscribe()` serialization should support the documentation's `subscription` versus `subscriptions` difference.
-- [ ] Check whether timestamp, price, and volume fields should preserve string precision instead of always converting to float.
+- [x] Add public channel support for MWallet Pool Quota.
+- [x] Add private channel support for Fast Trade.
+- [x] Add MWallet private channels: order, trade, fast trade, account, AD ratio, and borrowing.
+- [x] Add book response fields: `fi`, `li`, and `v`.
+- [x] Add a `market_status` subscription test.
+- [x] Check whether `Request.unsubscribe()` serialization should support the documentation's `subscription` versus `subscriptions` difference.
+- [x] Check whether timestamp, price, and volume fields should preserve string precision instead of always converting to float.
 
 ## Documentation
 

--- a/src/maicoin/ws/__init__.py
+++ b/src/maicoin/ws/__init__.py
@@ -1,6 +1,10 @@
 from maicoin.ws.balance import Balance
 from maicoin.ws.channel import Channel
 from maicoin.ws.kline import KLine
+from maicoin.ws.m_wallet import MWalletADRatio
+from maicoin.ws.m_wallet import MWalletBorrowing
+from maicoin.ws.m_wallet import MWalletIndexPrice
+from maicoin.ws.m_wallet import PoolQuota
 from maicoin.ws.order import Order
 from maicoin.ws.order import OrderState
 from maicoin.ws.order import OrderType
@@ -22,9 +26,13 @@ __all__ = [
     "Event",
     "Filter",
     "KLine",
+    "MWalletADRatio",
+    "MWalletBorrowing",
+    "MWalletIndexPrice",
     "Order",
     "OrderState",
     "OrderType",
+    "PoolQuota",
     "Request",
     "Response",
     "Side",

--- a/src/maicoin/ws/balance.py
+++ b/src/maicoin/ws/balance.py
@@ -10,12 +10,14 @@ from pydantic import field_validator
 
 class Balance(BaseModel):
     currency: str = Field(validation_alias="cu")
-    available: float = Field(validation_alias="av")
-    locked: float = Field(validation_alias="l")
-    staked: str | float | None = Field(default=None, validation_alias="stk")
-    balance_updated_time: datetime = Field(validation_alias="TU")
+    available: str = Field(validation_alias="av")
+    locked: str = Field(validation_alias="l")
+    staked: str | None = Field(default=None, validation_alias="stk")
+    balance_updated_time: datetime | None = Field(default=None, validation_alias="TU")
 
     @field_validator("balance_updated_time", mode="before")
     @classmethod
-    def convert_datetime(cls, t: int) -> datetime:
+    def convert_datetime(cls, t: int | None) -> datetime | None:
+        if t is None:
+            return None
         return datetime.fromtimestamp(int(t) / 1000, tz=UTC)

--- a/src/maicoin/ws/channel.py
+++ b/src/maicoin/ws/channel.py
@@ -8,3 +8,4 @@ class Channel(StrEnum):
     USER = "user"
     KLINE = "kline"
     MARKET_STATUS = "market_status"
+    POOL_QUOTA = "pool_quota"

--- a/src/maicoin/ws/kline.py
+++ b/src/maicoin/ws/kline.py
@@ -15,11 +15,11 @@ class KLine(BaseModel):
     end_time: datetime = Field(validation_alias="ET")
     market: str = Field(validation_alias="M")
     resolution: RESOLUTION = Field(validation_alias="R")
-    open: float = Field(validation_alias="O")
-    high: float = Field(validation_alias="H")
-    low: float = Field(validation_alias="L")
-    close: float = Field(validation_alias="C")
-    volume: float = Field(validation_alias="v")
+    open: str = Field(validation_alias="O")
+    high: str = Field(validation_alias="H")
+    low: str = Field(validation_alias="L")
+    close: str = Field(validation_alias="C")
+    volume: str = Field(validation_alias="v")
     last_trade_id: int = Field(validation_alias="ti")
     closed: bool = Field(validation_alias="x")
 
@@ -27,8 +27,3 @@ class KLine(BaseModel):
     @classmethod
     def convert_datetime(cls, t: int) -> datetime:
         return datetime.fromtimestamp(int(t) / 1000, tz=UTC)
-
-    @field_validator("open", "high", "low", "close", "volume", mode="before")
-    @classmethod
-    def convert_float(cls, s: str) -> float:
-        return float(s)

--- a/src/maicoin/ws/m_wallet.py
+++ b/src/maicoin/ws/m_wallet.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import UTC
+from datetime import datetime
+
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import field_validator
+
+
+class PoolQuota(BaseModel):
+    currency: str = Field(validation_alias="cu")
+    available: str = Field(validation_alias="av")
+    updated_at: datetime = Field(validation_alias="TU")
+
+    @field_validator("updated_at", mode="before")
+    @classmethod
+    def convert_datetime(cls, t: int) -> datetime:
+        return datetime.fromtimestamp(int(t) / 1000, tz=UTC)
+
+
+class MWalletIndexPrice(BaseModel):
+    market: str = Field(validation_alias="M")
+    price: str = Field(validation_alias="p")
+
+
+class MWalletADRatio(BaseModel):
+    ad_ratio: str = Field(validation_alias="ad")
+    asset_in_usdt: str = Field(validation_alias="as")
+    debt_in_usdt: str = Field(validation_alias="db")
+    index_prices: list[MWalletIndexPrice] = Field(validation_alias="idxp")
+    updated_at: datetime = Field(validation_alias="TU")
+
+    @field_validator("updated_at", mode="before")
+    @classmethod
+    def convert_datetime(cls, t: int) -> datetime:
+        return datetime.fromtimestamp(int(t) / 1000, tz=UTC)
+
+
+class MWalletBorrowing(BaseModel):
+    currency: str = Field(validation_alias="cu")
+    debt_principal: str = Field(validation_alias="dbp")
+    debt_interest: str = Field(validation_alias="dbi")
+    updated_at: datetime = Field(validation_alias="TU")
+
+    @field_validator("updated_at", mode="before")
+    @classmethod
+    def convert_datetime(cls, t: int) -> datetime:
+        return datetime.fromtimestamp(int(t) / 1000, tz=UTC)

--- a/src/maicoin/ws/order.py
+++ b/src/maicoin/ws/order.py
@@ -33,27 +33,23 @@ class Order(BaseModel):
     order_id: int = Field(validation_alias="i")
     side: Side = Field(validation_alias="sd")
     order_type: OrderType = Field(validation_alias="ot")
-    price: float = Field(validation_alias="p")
-    stop_price: float | None = Field(default=None, validation_alias="sp")
-    average_price: float = Field(validation_alias="ap")
+    price: str = Field(validation_alias="p")
+    stop_price: str | None = Field(default=None, validation_alias="sp")
+    average_price: str = Field(validation_alias="ap")
     state: OrderState = Field(validation_alias="S")
     market: str = Field(validation_alias="M")
     created_at: datetime = Field(validation_alias="T")
-    volume: float = Field(validation_alias="v")
-    remaining_volume: float = Field(validation_alias="rv")
-    executed_volume: float = Field(validation_alias="ev")
+    updated_at: datetime | None = Field(default=None, validation_alias="TU")
+    volume: str = Field(validation_alias="v")
+    remaining_volume: str = Field(validation_alias="rv")
+    executed_volume: str = Field(validation_alias="ev")
     trade_count: int = Field(validation_alias="tc")
-    client_order_id: str = Field(validation_alias="ci")
+    client_order_id: str | None = Field(validation_alias="ci")
     group_id: int | None = Field(default=None, validation_alias="gi")
 
-    @field_validator("created_at", mode="before")
+    @field_validator("created_at", "updated_at", mode="before")
     @classmethod
-    def convert_datetime(cls, t: int) -> datetime:
+    def convert_datetime(cls, t: int | None) -> datetime | None:
+        if t is None:
+            return None
         return datetime.fromtimestamp(int(t) / 1000, tz=UTC)
-
-    @field_validator(
-        "price", "average_price", "stop_price", "volume", "remaining_volume", "executed_volume", mode="before"
-    )
-    @classmethod
-    def convert_float(cls, s: str) -> float:
-        return float(s)

--- a/src/maicoin/ws/request.py
+++ b/src/maicoin/ws/request.py
@@ -23,6 +23,12 @@ class Filter(StrEnum):
     TRADE = "trade"
     ACCOUNT = "account"
     TRADE_UPDATE = "trade_update"
+    MWALLET_ORDER = "mwallet_order"
+    MWALLET_TRADE = "mwallet_trade"
+    MWALLET_FAST_TRADE_UPDATE = "mwallet_fast_trade_update"
+    MWALLET_ACCOUNT = "mwallet_account"
+    AD_RATIO = "ad_ratio"
+    BORROWING = "borrowing"
 
 
 class Request(BaseModel):
@@ -33,6 +39,7 @@ class Request(BaseModel):
     signature: str | None = None
     filters: list[Filter] | None = None
     subscriptions: list[Subscription] | None = None
+    subscription: list[Subscription] | None = None
 
     @classmethod
     def auth(cls, api_key: str, api_secret: str) -> Request:
@@ -63,7 +70,7 @@ class Request(BaseModel):
         return cls(
             action=Action.Unsubscribe,
             id=str(uuid.uuid4()),
-            subscriptions=subscriptions,
+            subscription=subscriptions,
         )
 
     def message(self) -> str:

--- a/src/maicoin/ws/response.py
+++ b/src/maicoin/ws/response.py
@@ -11,6 +11,9 @@ from pydantic import field_validator
 from maicoin.ws.balance import Balance
 from maicoin.ws.channel import Channel
 from maicoin.ws.kline import KLine
+from maicoin.ws.m_wallet import MWalletADRatio
+from maicoin.ws.m_wallet import MWalletBorrowing
+from maicoin.ws.m_wallet import PoolQuota
 from maicoin.ws.market_status import MarketStatus
 from maicoin.ws.order import Order
 from maicoin.ws.subscription import Subscription
@@ -31,6 +34,18 @@ class Event(StrEnum):
     TRADE_UPDATE = "trade_update"
     ACCOUNT_SNAPSHOT = "account_snapshot"
     ACCOUNT_UPDATE = "account_update"
+    FAST_TRADE_UPDATE = "fast_trade_update"
+    MWALLET_ORDER_SNAPSHOT = "mwallet_order_snapshot"
+    MWALLET_ORDER_UPDATE = "mwallet_order_update"
+    MWALLET_TRADE_SNAPSHOT = "mwallet_trade_snapshot"
+    MWALLET_TRADE_UPDATE = "mwallet_trade_update"
+    MWALLET_FAST_TRADE_UPDATE = "mwallet_fast_trade_update"
+    MWALLET_ACCOUNT_SNAPSHOT = "mwallet_account_snapshot"
+    MWALLET_ACCOUNT_UPDATE = "mwallet_account_update"
+    AD_RATIO_SNAPSHOT = "ad_ratio_snapshot"
+    AD_RATIO_UPDATE = "ad_ratio_update"
+    BORROWING_SNAPSHOT = "borrowing_snapshot"
+    BORROWING_UPDATE = "borrowing_update"
 
 
 # https://maicoin.github.io/max-websocket-docs/#/?id=response-key-alias
@@ -43,14 +58,20 @@ class Response(BaseModel):
     channel: Channel | None = Field(default=None, validation_alias="c")
     balances: list[Balance] | None = Field(default=None, validation_alias="B")
     market: str | None = Field(default=None, validation_alias="M")
-    asks: list[list[float]] | None = Field(default=None, validation_alias="a")
-    bids: list[list[float]] | None = Field(default=None, validation_alias="b")
+    asks: list[list[str]] | None = Field(default=None, validation_alias="a")
+    bids: list[list[str]] | None = Field(default=None, validation_alias="b")
+    first_update_id: int | None = Field(default=None, validation_alias="fi")
+    last_update_id: int | None = Field(default=None, validation_alias="li")
+    version: int | None = Field(default=None, validation_alias="v")
     orders: list[Order] | None = Field(default=None, validation_alias="o")
     ticker: Ticker | None = Field(default=None, validation_alias="tk")
     trades: list[Trade] | None = Field(default=None, validation_alias="t")
     currency: str | None = Field(default=None, validation_alias="cu")
     kline: KLine | None = Field(default=None, validation_alias="k")
     market_status: list[MarketStatus] | None = Field(default=None, validation_alias="ms")
+    pool_quota: PoolQuota | None = Field(default=None, validation_alias="qta")
+    m_wallet_ad_ratio: MWalletADRatio | None = Field(default=None, validation_alias="ad")
+    m_wallet_borrowings: list[MWalletBorrowing] | None = Field(default=None, validation_alias="db")
 
     @field_validator("created_at", mode="before")
     @classmethod

--- a/src/maicoin/ws/subscription.py
+++ b/src/maicoin/ws/subscription.py
@@ -10,3 +10,4 @@ class Subscription(BaseModel):
     market: str | None = None
     depth: int | None = None
     resolution: str | None = None
+    currency: str | None = None

--- a/src/maicoin/ws/ticker.py
+++ b/src/maicoin/ws/ticker.py
@@ -2,20 +2,14 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 from pydantic import Field
-from pydantic import field_validator
 
 
 # https://maicoin.github.io/max-websocket-docs/#/public_ticker?id=success-response
 class Ticker(BaseModel):
     market: str = Field(validation_alias="M")
-    open: float = Field(validation_alias="O")
-    high: float = Field(validation_alias="H")
-    low: float = Field(validation_alias="L")
-    close: float = Field(validation_alias="C")
-    volume: float = Field(validation_alias="v")
-    volume_in_btc: float = Field(validation_alias="V")
-
-    @field_validator("open", "high", "low", "close", "volume", "volume_in_btc", mode="before")
-    @classmethod
-    def convert_float(cls, s: str) -> float:
-        return float(s)
+    open: str = Field(validation_alias="O")
+    high: str = Field(validation_alias="H")
+    low: str = Field(validation_alias="L")
+    close: str = Field(validation_alias="C")
+    volume: str = Field(validation_alias="v")
+    volume_in_btc: str = Field(validation_alias="V")

--- a/src/maicoin/ws/trade.py
+++ b/src/maicoin/ws/trade.py
@@ -15,9 +15,9 @@ class Trade(BaseModel):
     id: int | None = Field(default=None, validation_alias="i")
     market: str | None = Field(default=None, validation_alias="M")
     side: Side | None = Field(default=None, validation_alias="sd")
-    price: float = Field(validation_alias="p")
-    volume: float = Field(validation_alias="v")
-    fee: float | None = Field(default=None, validation_alias="f")
+    price: str = Field(validation_alias="p")
+    volume: str = Field(validation_alias="v")
+    fee: str | None = Field(default=None, validation_alias="f")
     fee_currency: str | None = Field(default=None, validation_alias="fc")
     fee_discounted: bool | None = Field(default=None, validation_alias="fd")
     funds: str | None = Field(default=None, validation_alias="fn")
@@ -29,10 +29,7 @@ class Trade(BaseModel):
 
     @field_validator("created_at", "updated_at", mode="before")
     @classmethod
-    def convert_datetime(cls, t: int) -> datetime:
+    def convert_datetime(cls, t: int | None) -> datetime | None:
+        if t is None:
+            return None
         return datetime.fromtimestamp(int(t) / 1000, tz=UTC)
-
-    @field_validator("price", "volume", "fee", mode="before")
-    @classmethod
-    def convert_float(cls, s: str) -> float:
-        return float(s)

--- a/tests/ws/test_request.py
+++ b/tests/ws/test_request.py
@@ -1,3 +1,8 @@
+import json
+
+from maicoin.ws import Channel
+from maicoin.ws import Filter
+from maicoin.ws import Subscription
 from maicoin.ws.request import Request
 
 
@@ -30,6 +35,14 @@ def test_action_unsubscribe() -> None:
     Request.model_validate(d)
 
 
+def test_unsubscribe_message_uses_documented_singular_subscription_key() -> None:
+    request = Request.unsubscribe([Subscription(channel=Channel.BOOK, market="btctwd", depth=1)])
+    message = json.loads(request.message())
+
+    assert "subscription" in message
+    assert "subscriptions" not in message
+
+
 # https://maicoin.github.io/max-websocket-docs/#/authentication?id=subscription
 def test_action_auth() -> None:
     d = {
@@ -55,3 +68,32 @@ def test_action_auth_filters() -> None:
     }
 
     Request.model_validate(d)
+
+
+def test_action_auth_mwallet_filters() -> None:
+    d = {
+        "action": "auth",
+        "apiKey": "...",
+        "nonce": 1591690054859,
+        "signature": "....",
+        "id": "client-id",
+        "filters": [
+            "mwallet_order",
+            "mwallet_trade",
+            "mwallet_fast_trade_update",
+            "mwallet_account",
+            "ad_ratio",
+            "borrowing",
+        ],
+    }
+
+    request = Request.model_validate(d)
+
+    assert request.filters == [
+        Filter.MWALLET_ORDER,
+        Filter.MWALLET_TRADE,
+        Filter.MWALLET_FAST_TRADE_UPDATE,
+        Filter.MWALLET_ACCOUNT,
+        Filter.AD_RATIO,
+        Filter.BORROWING,
+    ]

--- a/tests/ws/test_response.py
+++ b/tests/ws/test_response.py
@@ -378,3 +378,226 @@ def test_response_market_status_update() -> None:
     }
 
     Response.model_validate(d)
+
+
+def test_response_book_snapshot_preserves_string_levels_and_parses_update_ids() -> None:
+    d = {
+        "c": "book",
+        "e": "snapshot",
+        "M": "btcusdt",
+        "a": [["5337.3000000000000001", "0.1"]],
+        "b": [["5333.3", "0.5"]],
+        "T": 1591869939634,
+        "fi": 12141725,
+        "li": 12141725,
+        "v": 1725602999632,
+    }
+
+    response = Response.model_validate(d)
+
+    assert response.asks == [["5337.3000000000000001", "0.1"]]
+    assert response.first_update_id == 12141725
+    assert response.last_update_id == 12141725
+    assert response.version == 1725602999632
+
+
+# https://maicoin.github.io/max-websocket-docs/#/public_mwallet_pool_quota?id=success-response
+def test_response_mwallet_pool_quota() -> None:
+    d = {
+        "c": "pool_quota",
+        "e": "snapshot",
+        "qta": {
+            "cu": "usdt",
+            "av": "501353.81385068",
+            "TU": 1641551141618,
+        },
+        "T": 1641772933737,
+    }
+
+    response = Response.model_validate(d)
+
+    assert response.pool_quota is not None
+    assert response.pool_quota.currency == "usdt"
+    assert response.pool_quota.available == "501353.81385068"
+
+
+# https://maicoin.github.io/max-websocket-docs/#/private_channels?id=fast-trade-response
+def test_response_private_fast_trade_update() -> None:
+    d = {
+        "c": "user",
+        "e": "fast_trade_update",
+        "t": [
+            {
+                "i": 68444,
+                "M": "ethtwd",
+                "sd": "bid",
+                "p": "21499.0",
+                "v": "0.2658",
+                "fn": "5714.4342",
+                "T": 1659216053748,
+                "TU": 1659216054046,
+                "m": True,
+                "oi": 3253823664,
+            },
+        ],
+        "T": 1521726960357,
+    }
+
+    response = Response.model_validate(d)
+
+    assert response.trades is not None
+    assert response.trades[0].price == "21499.0"
+
+
+# https://maicoin.github.io/max-websocket-docs/#/private_channels_mwallet?id=mwallet-order-response
+def test_response_mwallet_order_snapshot() -> None:
+    d = {
+        "c": "user",
+        "e": "mwallet_order_snapshot",
+        "o": [
+            {
+                "i": 87,
+                "sd": "bid",
+                "ot": "limit",
+                "p": "3320.49",
+                "sp": None,
+                "ap": "0.0",
+                "v": "0.1",
+                "rv": "0.1",
+                "ev": "0.0",
+                "S": "wait",
+                "M": "ethusdt",
+                "tc": 0,
+                "T": 1633415952000,
+                "TU": 1633415952701,
+                "ci": "client-oid-1",
+                "gi": 123,
+            },
+        ],
+        "T": 1633415952715,
+    }
+
+    response = Response.model_validate(d)
+
+    assert response.orders is not None
+    assert response.orders[0].price == "3320.49"
+
+
+# https://maicoin.github.io/max-websocket-docs/#/private_channels_mwallet?id=mwallet-trade-response
+def test_response_mwallet_trade_update() -> None:
+    d = {
+        "c": "user",
+        "e": "mwallet_trade_update",
+        "t": [
+            {
+                "i": 78,
+                "M": "ethusdt",
+                "sd": "bid",
+                "p": "3320.49",
+                "v": "0.1",
+                "f": "0.00015",
+                "fc": "eth",
+                "fn": "77.38889",
+                "T": 1633359451377,
+                "TU": 1633359451378,
+                "m": False,
+                "oi": 123,
+            },
+        ],
+        "T": 1521726960357,
+    }
+
+    response = Response.model_validate(d)
+
+    assert response.trades is not None
+    assert response.trades[0].fee == "0.00015"
+
+
+# https://maicoin.github.io/max-websocket-docs/#/private_channels_mwallet?id=mwallet-fast-trade-response
+def test_response_mwallet_fast_trade_update() -> None:
+    d = {
+        "c": "user",
+        "e": "mwallet_fast_trade_update",
+        "t": [
+            {
+                "i": 78,
+                "M": "ethusdt",
+                "sd": "bid",
+                "p": "3320.49",
+                "v": "0.1",
+                "fn": "77.38889",
+                "T": 1633359451377,
+                "TU": 1633359451378,
+                "m": False,
+                "oi": 123,
+            },
+        ],
+        "T": 1521726960357,
+    }
+
+    Response.model_validate(d)
+
+
+# https://maicoin.github.io/max-websocket-docs/#/private_channels_mwallet?id=mwallet-account-response
+def test_response_mwallet_account_update_without_balance_update_time() -> None:
+    d = {
+        "c": "user",
+        "e": "mwallet_account_update",
+        "B": [
+            {
+                "cu": "btc",
+                "av": "123.4",
+                "l": "0.5",
+                "stk": None,
+            },
+        ],
+        "T": 1521726960357,
+    }
+
+    response = Response.model_validate(d)
+
+    assert response.balances is not None
+    assert response.balances[0].balance_updated_time is None
+
+
+# https://maicoin.github.io/max-websocket-docs/#/private_channels_mwallet?id=mwallet-ad-ratio-response
+def test_response_mwallet_ad_ratio_update() -> None:
+    d = {
+        "c": "user",
+        "e": "ad_ratio_update",
+        "ad": {
+            "ad": "38.08306432",
+            "as": "132071.22",
+            "db": "3467.97775784",
+            "idxp": [{"M": "btcusdt", "p": "63190.045"}],
+            "TU": 1521726960300,
+        },
+        "T": 1521726960357,
+    }
+
+    response = Response.model_validate(d)
+
+    assert response.m_wallet_ad_ratio is not None
+    assert response.m_wallet_ad_ratio.index_prices[0].price == "63190.045"
+
+
+# https://maicoin.github.io/max-websocket-docs/#/private_channels_mwallet?id=mwallet-borrowing-response
+def test_response_mwallet_borrowing_update() -> None:
+    d = {
+        "c": "user",
+        "e": "borrowing_update",
+        "db": [
+            {
+                "cu": "usdt",
+                "dbp": "500.0",
+                "dbi": "0.00004488",
+                "TU": 1521726960300,
+            },
+        ],
+        "T": 1521726960357,
+    }
+
+    response = Response.model_validate(d)
+
+    assert response.m_wallet_borrowings is not None
+    assert response.m_wallet_borrowings[0].debt_interest == "0.00004488"

--- a/tests/ws/test_subscription.py
+++ b/tests/ws/test_subscription.py
@@ -41,3 +41,22 @@ def test_subscription_kline() -> None:
     }
 
     Subscription.model_validate(d)
+
+
+# https://maicoin.github.io/max-websocket-docs/#/public_market_status?id=market-status-subscription
+def test_subscription_market_status() -> None:
+    d = {
+        "channel": "market_status",
+    }
+
+    Subscription.model_validate(d)
+
+
+# https://maicoin.github.io/max-websocket-docs/#/public_mwallet_pool_quota?id=mwallet-pool-quota-subscription
+def test_subscription_mwallet_pool_quota() -> None:
+    d = {
+        "channel": "pool_quota",
+        "currency": "usdt",
+    }
+
+    Subscription.model_validate(d)


### PR DESCRIPTION
## Summary
- Add WebSocket M-Wallet pool quota and private channel parsing support
- Add fast trade and M-Wallet auth filters
- Preserve string precision for WebSocket price and amount fields
- Emit documented singular `subscription` key for unsubscribe requests
- Mark Phase 7 TODO items complete

## Tests
- just