### PR TITLE
docs: expand api usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ python example.py
 
 ## REST API v3
 
-REST v3 support includes the foundation client, authentication helpers, error handling, public endpoint wrappers, and typed public response models.
+REST v3 support includes the foundation client, authentication helpers, error handling, public/private endpoint wrappers,
+and typed response models.
 
 ### Public requests
 
@@ -51,9 +52,27 @@ client = Client()
 markets = client.request("GET", "/api/v3/markets")
 ```
 
-### Low-level private request
+### Private requests
 
-Private requests require MAX credentials and are signed with `X-MAX-ACCESSKEY`, `X-MAX-PAYLOAD`, and `X-MAX-SIGNATURE` headers.
+Private requests require MAX credentials and are signed with `X-MAX-ACCESSKEY`, `X-MAX-PAYLOAD`, and
+`X-MAX-SIGNATURE` headers.
+
+```python
+import os
+
+from maicoin.v3 import Client
+
+client = Client(
+    api_key=os.environ["MAX_API_KEY"],
+    api_secret=os.environ["MAX_API_SECRET"],
+)
+
+accounts = client.accounts()
+open_orders = client.open_orders(market="btctwd")
+withdrawals = client.withdrawals(currency="btc", limit=10)
+```
+
+Use `Client.request(...)` for low-level private access when a high-level wrapper is not available:
 
 ```python
 import os
@@ -67,4 +86,37 @@ client = Client(
 accounts = client.request("GET", "/api/v3/wallet/spot/accounts", auth=True)
 ```
 
-Do not run state-changing private requests, such as order creation or withdrawals, without reviewing the parameters carefully.
+> [!WARNING]
+> Some private methods create real account actions, including orders, withdrawals, loans, transfers, repayments,
+> and converts. Review parameters carefully before calling state-changing methods.
+
+## WebSocket API
+
+Use `Stream` with one or more subscriptions to receive typed WebSocket responses:
+
+```python
+from maicoin.ws import Channel
+from maicoin.ws import Response
+from maicoin.ws import Stream
+from maicoin.ws import Subscription
+
+
+def handle_response(response: Response) -> None:
+    print(response.model_dump(exclude_none=True))
+
+
+stream = Stream()
+stream.subscribe(
+    [
+        Subscription(channel=Channel.BOOK, market="btcusdt", depth=5),
+        Subscription(channel=Channel.TICKER, market="btcusdt"),
+        Subscription(channel=Channel.TRADE, market="btcusdt"),
+        Subscription(channel=Channel.MARKET_STATUS),
+    ]
+)
+stream.add_handler(handle_response)
+stream.run()
+```
+
+For authenticated private WebSocket channels, create the stream with credentials or use `Stream.from_env()` with
+`MAX_API_KEY` and `MAX_API_SECRET`.


### PR DESCRIPTION
## Summary
- Add high-level REST v3 private API examples
- Keep low-level private request example
- Add warning for state-changing private methods
- Add minimal WebSocket Stream example

## Tests
- Not run (docs-only changes)