### PR TITLE
Move python-dotenv to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors         = [{ name = "narumi", email = "toucans-cutouts0f@icloud.com" }]
 dependencies    = [
   "httpx>=0.28.1",
   "pydantic>=2.13.4",
-  "python-dotenv>=1.2.2",
   "websockets>=16.0",
 ]
 
@@ -16,6 +15,7 @@ dependencies    = [
 dev = [
   "pytest>=9.0.3",
   "pytest-cov>=7.1.0",
+  "python-dotenv>=1.2.2",
   "rich>=15.0.0",
   "ruff>=0.15.12",
   "ty>=0.0.34",

--- a/uv.lock
+++ b/uv.lock
@@ -188,7 +188,6 @@ source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
-    { name = "python-dotenv" },
     { name = "websockets" },
 ]
 
@@ -196,6 +195,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "python-dotenv" },
     { name = "rich" },
     { name = "ruff" },
     { name = "ty" },
@@ -205,7 +205,6 @@ dev = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.13.4" },
-    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "websockets", specifier = ">=16.0" },
 ]
 
@@ -213,6 +212,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "rich", specifier = ">=15.0.0" },
     { name = "ruff", specifier = ">=0.15.12" },
     { name = "ty", specifier = ">=0.0.34" },


### PR DESCRIPTION
## Summary
- move python-dotenv out of runtime dependencies and into the dev group
- refresh uv.lock

## Tests
- just