### PR TITLE
Add live integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ just         # format, lint, type-check, test
 just test    # pytest with coverage
 ```
 
+### Live integration tests
+
+Live tests call the real MAX API and are skipped unless explicitly enabled:
+
+```shell
+RUN_LIVE_TESTS=1 uv run pytest -v -s -m live tests/live
+# or
+just live-test
+```
+
+Private read-only live tests also require `MAX_API_KEY` and `MAX_API_SECRET`; `just` loads these from `.env` automatically. Set `MAX_LIVE_MARKET` to override the default public test market (`btctwd`). Destructive live tests are intentionally not implemented yet.
+
 ## 📚 References
 
 - HTTP API v3: <https://max-api.maicoin.com/doc/v3.html>

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,12 +4,12 @@
 
 Plan: [`docs/live-integration-tests-plan.md`](live-integration-tests-plan.md)
 
-- [ ] Register `live` and `destructive` pytest markers in `pyproject.toml`.
-- [ ] Create `tests/live/` with shared fixtures and skip logic.
-- [ ] Implement public live tests for read-only MAX REST v3 public endpoints.
-- [ ] Add a `just live-test` recipe.
-- [ ] Implement private read-only live tests that use `MAX_API_KEY` and `MAX_API_SECRET` when available.
-- [ ] Update `README.md` with a short section explaining how to run live integration tests.
+- [x] Register `live` and `destructive` pytest markers in `pyproject.toml`.
+- [x] Create `tests/live/` with shared fixtures and skip logic.
+- [x] Implement public live tests for read-only MAX REST v3 public endpoints.
+- [x] Add a `just live-test` recipe.
+- [x] Implement private read-only live tests that use `MAX_API_KEY` and `MAX_API_SECRET` when available.
+- [x] Update `README.md` with a short section explaining how to run live integration tests.
 - [ ] Leave destructive live tests for a separate design pass; do not include them in the first implementation.
 
 ## Completed Milestones

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set dotenv-load := true
+
 [default]
 all: format lint type test
 
@@ -16,6 +18,10 @@ type:
 # Run tests using pytest with coverage
 test:
     uv run pytest -v -s --cov=src tests
+
+# Run live integration tests against the real MAX API
+live-test:
+    RUN_LIVE_TESTS=1 uv run pytest -v -s -m live tests/live
 
 # Build and publish the package to PyPI
 publish:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ tag              = true
 commit           = true
 pre_commit_hooks = ["uv lock", "git add uv.lock"]
 
+[tool.pytest]
+markers = [
+  "destructive: live tests that may change account state",
+  "live: tests that call the real MaiCoin MAX API",
+]
+
 [tool.ruff]
 line-length = 120
 

--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -95,13 +95,15 @@ class Client:
             if self.api_key is None or self.api_secret is None:
                 msg = "api_key and api_secret are required for authenticated requests"
                 raise ValueError(msg)
+            nonce = self.nonce_factory()
+            request_params = {"nonce": nonce, **request_params}
             headers.update(
                 build_auth_headers(
                     api_key=self.api_key,
                     api_secret=self.api_secret,
                     path=normalized_path,
                     params=request_params,
-                    nonce=self.nonce_factory(),
+                    nonce=nonce,
                 )
             )
 

--- a/src/maicoin/v3/models.py
+++ b/src/maicoin/v3/models.py
@@ -29,7 +29,7 @@ class Staking(MaxBaseModel):
 
 
 class CurrencyNetwork(MaxBaseModel):
-    token_contract_address: str
+    token_contract_address: str | None
     precision: int
     id: str
     network_protocol: str

--- a/tests/live/__init__.py
+++ b/tests/live/__init__.py
@@ -1,0 +1,1 @@
+"""Live integration tests for the real MaiCoin MAX API."""

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from maicoin.v3 import Client
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    if os.environ.get("RUN_LIVE_TESTS") == "1":
+        return
+
+    skip_live = pytest.mark.skip(reason="set RUN_LIVE_TESTS=1 to run live integration tests")
+    for item in items:
+        if "live" in item.keywords:
+            item.add_marker(skip_live)
+
+
+@pytest.fixture(scope="session")
+def live_market() -> str:
+    return os.environ.get("MAX_LIVE_MARKET", "btctwd")
+
+
+@pytest.fixture(scope="session")
+def public_client() -> Client:
+    return Client()
+
+
+@pytest.fixture(scope="session")
+def private_client() -> Client:
+    api_key = os.environ.get("MAX_API_KEY")
+    api_secret = os.environ.get("MAX_API_SECRET")
+    if api_key is None or api_secret is None:
+        pytest.skip("MAX_API_KEY and MAX_API_SECRET are required for private live tests")
+    return Client(api_key=api_key, api_secret=api_secret)

--- a/tests/live/test_private_readonly_live.py
+++ b/tests/live/test_private_readonly_live.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from maicoin.v3 import Client
+
+pytestmark = pytest.mark.live
+
+
+def test_info(private_client: Client) -> None:
+    info = private_client.info()
+
+    assert info.email
+    assert info.level >= 0
+    assert info.current_vip_level.level >= 0
+
+
+def test_accounts(private_client: Client) -> None:
+    accounts = private_client.accounts()
+
+    assert accounts
+    assert all(account.currency for account in accounts)
+
+
+def test_open_orders(private_client: Client) -> None:
+    orders = private_client.open_orders(limit=1)
+
+    assert len(orders) <= 1
+    for order in orders:
+        assert order.id > 0
+        assert order.wallet_type == "spot"
+
+
+def test_closed_orders(private_client: Client) -> None:
+    orders = private_client.closed_orders(limit=1)
+
+    assert len(orders) <= 1
+    for order in orders:
+        assert order.id > 0
+        assert order.wallet_type == "spot"
+
+
+def test_wallet_trades(private_client: Client) -> None:
+    trades = private_client.wallet_trades(limit=1)
+
+    assert len(trades) <= 1
+    for trade in trades:
+        assert trade.id > 0
+        assert trade.wallet_type == "spot"

--- a/tests/live/test_public_live.py
+++ b/tests/live/test_public_live.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from maicoin.v3 import Client
+
+pytestmark = pytest.mark.live
+
+
+def test_timestamp(public_client: Client) -> None:
+    timestamp = public_client.timestamp()
+
+    assert timestamp.timestamp > 0
+
+
+def test_markets_includes_live_market(public_client: Client, live_market: str) -> None:
+    markets = public_client.markets()
+
+    assert markets
+    assert any(market.id == live_market for market in markets)
+
+
+def test_currencies_returns_currency_models(public_client: Client) -> None:
+    currencies = public_client.currencies()
+
+    assert currencies
+    assert all(currency.currency for currency in currencies)
+
+
+def test_ticker(public_client: Client, live_market: str) -> None:
+    ticker = public_client.ticker(live_market)
+
+    assert ticker.market == live_market
+    assert ticker.at > 0
+    assert ticker.last is not None
+
+
+def test_tickers(public_client: Client, live_market: str) -> None:
+    tickers = public_client.tickers([live_market])
+
+    assert len(tickers) == 1
+    assert tickers[0].market == live_market
+
+
+def test_depth(public_client: Client, live_market: str) -> None:
+    depth = public_client.depth(live_market, limit=1)
+
+    assert depth.timestamp > 0
+    assert len(depth.asks) <= 1
+    assert len(depth.bids) <= 1
+
+
+def test_trades(public_client: Client, live_market: str) -> None:
+    trades = public_client.trades(live_market, limit=1)
+
+    assert len(trades) <= 1
+    for trade in trades:
+        assert trade.market == live_market
+        assert trade.id > 0
+
+
+def test_kline(public_client: Client, live_market: str) -> None:
+    klines = public_client.kline(live_market, limit=1)
+
+    assert len(klines) <= 1
+    for kline in klines:
+        assert kline.timestamp > 0
+        assert kline.open
+        assert kline.close

--- a/tests/v3/test_client.py
+++ b/tests/v3/test_client.py
@@ -89,6 +89,7 @@ def test_authenticated_request_adds_max_headers() -> None:
     )
     assert headers["X-MAX-SIGNATURE"] == "4347a83e4172fdf36e00c954deacfe143e77a360daef361106ff1ea852cceabe"
     assert headers["Content-Type"] == "application/json"
+    assert last_kwargs(session)["params"] == {"nonce": 123456, "currency": "btc"}
 
 
 def test_http_error_response_raises() -> None:

--- a/tests/v3/test_convert.py
+++ b/tests/v3/test_convert.py
@@ -78,6 +78,7 @@ def test_create_convert_constructs_authenticated_post_and_parses_payload() -> No
     assert session.calls[-1]["method"] == "POST"
     assert session.calls[-1]["url"] == "https://example.test/api/v3/convert"
     assert last_kwargs(session)["json"] == {
+        "nonce": 123456,
         "from_currency": "btc",
         "to_currency": "usdt",
         "from_amount": "0.01",
@@ -92,7 +93,7 @@ def test_convert_detail_constructs_authenticated_get_and_parses_payload() -> Non
     assert convert.sn == "6322d9bd-736b-4f19-b862-829e75cae1ce"
     assert session.calls[-1]["method"] == "GET"
     assert session.calls[-1]["url"] == "https://example.test/api/v3/convert"
-    assert last_kwargs(session)["params"] == {"sn": "6322d9bd-736b-4f19-b862-829e75cae1ce"}
+    assert last_kwargs(session)["params"] == {"nonce": 123456, "sn": "6322d9bd-736b-4f19-b862-829e75cae1ce"}
 
 
 def test_converts_constructs_authenticated_get_and_parses_list() -> None:
@@ -102,4 +103,4 @@ def test_converts_constructs_authenticated_get_and_parses_list() -> None:
     assert converts == [ConvertOrder.model_validate(convert_payload())]
     assert session.calls[-1]["method"] == "GET"
     assert session.calls[-1]["url"] == "https://example.test/api/v3/converts"
-    assert last_kwargs(session)["params"] == {"timestamp": 1704937708, "order": "desc", "limit": 1}
+    assert last_kwargs(session)["params"] == {"nonce": 123456, "timestamp": 1704937708, "order": "desc", "limit": 1}

--- a/tests/v3/test_funds.py
+++ b/tests/v3/test_funds.py
@@ -151,18 +151,22 @@ def test_withdrawal_methods_construct_authenticated_requests_and_parse_payloads(
 
     assert withdrawal == Withdrawal.model_validate(withdrawal_payload())
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/withdrawal"
-    assert last_kwargs(detail_session)["params"] == {"uuid": "18022603540001"}
+    assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "uuid": "18022603540001"}
 
     create_session = FakeSession(withdrawal_payload())
     authenticated_client(create_session).create_withdrawal(withdraw_address_uuid="addr-1", amount="0.019")
     assert create_session.calls[-1]["method"] == "POST"
-    assert last_kwargs(create_session)["json"] == {"withdraw_address_uuid": "addr-1", "amount": "0.019"}
+    assert last_kwargs(create_session)["json"] == {
+        "nonce": 123456,
+        "withdraw_address_uuid": "addr-1",
+        "amount": "0.019",
+    }
     assert last_payload(create_session)["path"] == "/api/v3/withdrawal"
 
     twd_session = FakeSession(withdrawal_payload(currency="twd", network_protocol=None, amount="100"))
     authenticated_client(twd_session).create_twd_withdrawal("100")
     assert twd_session.calls[-1]["url"] == "https://example.test/api/v3/withdrawal/twd"
-    assert last_kwargs(twd_session)["json"] == {"amount": "100"}
+    assert last_kwargs(twd_session)["json"] == {"nonce": 123456, "amount": "100"}
 
 
 def test_withdrawals_and_withdraw_addresses_parse_lists() -> None:
@@ -171,7 +175,12 @@ def test_withdrawals_and_withdraw_addresses_parse_lists() -> None:
 
     assert withdrawals == [Withdrawal.model_validate(withdrawal_payload())]
     assert withdrawals_session.calls[-1]["url"] == "https://example.test/api/v3/withdrawals"
-    assert last_kwargs(withdrawals_session)["params"] == {"currency": "usdt", "state": "done", "limit": 1}
+    assert last_kwargs(withdrawals_session)["params"] == {
+        "nonce": 123456,
+        "currency": "usdt",
+        "state": "done",
+        "limit": 1,
+    }
 
     address_payload = {
         "uuid": "508c9af6-ccc1-4122-b38f-a407e3bac96c",
@@ -189,7 +198,7 @@ def test_withdrawals_and_withdraw_addresses_parse_lists() -> None:
 
     assert addresses == [WithdrawAddress.model_validate(address_payload)]
     assert address_session.calls[-1]["url"] == "https://example.test/api/v3/withdraw_addresses"
-    assert last_kwargs(address_session)["params"] == {"currency": "usdt", "limit": 10, "offset": 20}
+    assert last_kwargs(address_session)["params"] == {"nonce": 123456, "currency": "usdt", "limit": 10, "offset": 20}
 
 
 def test_deposit_methods_construct_authenticated_requests_and_parse_payloads() -> None:
@@ -198,12 +207,12 @@ def test_deposit_methods_construct_authenticated_requests_and_parse_payloads() -
 
     assert deposit == Deposit.model_validate(deposit_payload())
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/deposit"
-    assert last_kwargs(detail_session)["params"] == {"uuid": "18022603540001"}
+    assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "uuid": "18022603540001"}
 
     deposits_session = FakeSession([deposit_payload()])
     deposits = authenticated_client(deposits_session).deposits(currency="usdt", order="asc", limit=1)
     assert deposits == [Deposit.model_validate(deposit_payload())]
-    assert last_kwargs(deposits_session)["params"] == {"currency": "usdt", "order": "asc", "limit": 1}
+    assert last_kwargs(deposits_session)["params"] == {"nonce": 123456, "currency": "usdt", "order": "asc", "limit": 1}
 
     address_payload = {
         "currency": "usdt",
@@ -215,7 +224,7 @@ def test_deposit_methods_construct_authenticated_requests_and_parse_payloads() -
     address = authenticated_client(address_session).deposit_address("trc20usdt")
     assert address == DepositAddress.model_validate(address_payload)
     assert address_session.calls[-1]["url"] == "https://example.test/api/v3/deposit_address"
-    assert last_kwargs(address_session)["params"] == {"currency_version": "trc20usdt"}
+    assert last_kwargs(address_session)["params"] == {"nonce": 123456, "currency_version": "trc20usdt"}
 
 
 def test_internal_transfers_and_rewards_construct_requests_and_parse_payloads() -> None:
@@ -233,7 +242,7 @@ def test_internal_transfers_and_rewards_construct_requests_and_parse_payloads() 
 
     assert transfers == [InternalTransfer.model_validate(transfer_payload)]
     assert transfers[0].from_ == "pr***@***.com"
-    assert last_kwargs(transfer_session)["params"] == {"side": "in", "currency": "eth", "limit": 1}
+    assert last_kwargs(transfer_session)["params"] == {"nonce": 123456, "side": "in", "currency": "eth", "limit": 1}
 
     reward_payload = {
         "uuid": "18032011380001",
@@ -248,7 +257,7 @@ def test_internal_transfers_and_rewards_construct_requests_and_parse_payloads() 
 
     assert rewards == [Reward.model_validate(reward_payload)]
     assert reward_session.calls[-1]["url"] == "https://example.test/api/v3/rewards"
-    assert last_kwargs(reward_session)["params"] == {"reward_type": "airdrop_reward", "limit": 1}
+    assert last_kwargs(reward_session)["params"] == {"nonce": 123456, "reward_type": "airdrop_reward", "limit": 1}
 
 
 def test_fund_transaction_deposit_methods_parse_list_and_detail() -> None:
@@ -260,12 +269,17 @@ def test_fund_transaction_deposit_methods_parse_list_and_detail() -> None:
     assert deposits == [FundTransactionDeposit.model_validate(fund_deposit_payload())]
     assert deposits[0].from_ is None
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/deposits"
-    assert last_kwargs(list_session)["params"] == {"timestamp": 1521726960123, "order": "desc", "limit": 1}
+    assert last_kwargs(list_session)["params"] == {
+        "nonce": 123456,
+        "timestamp": 1521726960123,
+        "order": "desc",
+        "limit": 1,
+    }
 
     detail_session = FakeSession(fund_deposit_payload())
     assert authenticated_client(detail_session).fund_transaction_deposit("18022603540001").sn == "18022603540001"
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/deposit"
-    assert last_kwargs(detail_session)["params"] == {"sn": "18022603540001"}
+    assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "sn": "18022603540001"}
 
 
 def test_fund_transaction_withdrawal_methods_parse_list_and_detail() -> None:
@@ -274,12 +288,12 @@ def test_fund_transaction_withdrawal_methods_parse_list_and_detail() -> None:
 
     assert withdrawals == [FundTransactionWithdrawal.model_validate(fund_withdrawal_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/withdrawals"
-    assert last_kwargs(list_session)["params"] == {"limit": 1}
+    assert last_kwargs(list_session)["params"] == {"nonce": 123456, "limit": 1}
 
     detail_session = FakeSession(fund_withdrawal_payload())
     assert authenticated_client(detail_session).fund_transaction_withdrawal("18022603540001").sn == "18022603540001"
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/withdrawal"
-    assert last_kwargs(detail_session)["params"] == {"sn": "18022603540001"}
+    assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "sn": "18022603540001"}
 
 
 def test_fund_transaction_transfer_methods_parse_list_and_detail() -> None:
@@ -289,9 +303,9 @@ def test_fund_transaction_transfer_methods_parse_list_and_detail() -> None:
     assert transfers == [FundTransactionTransfer.model_validate(fund_transfer_payload())]
     assert transfers[0].from_.wallet_type == "spot"
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/transfers"
-    assert last_kwargs(list_session)["params"] == {"limit": 1}
+    assert last_kwargs(list_session)["params"] == {"nonce": 123456, "limit": 1}
 
     detail_session = FakeSession(fund_transfer_payload())
     assert authenticated_client(detail_session).fund_transaction_transfer("18022603540001").sn == "18022603540001"
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/transfer"
-    assert last_kwargs(detail_session)["params"] == {"sn": "18022603540001"}
+    assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "sn": "18022603540001"}

--- a/tests/v3/test_m_wallet_private.py
+++ b/tests/v3/test_m_wallet_private.py
@@ -139,7 +139,7 @@ def test_create_m_wallet_loan_and_history_construct_authenticated_requests() -> 
     assert loan == MWalletLoan.model_validate(loan_payload())
     assert create_session.calls[-1]["method"] == "POST"
     assert create_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/loan"
-    assert last_kwargs(create_session)["json"] == {"currency": "eth", "amount": "0.019"}
+    assert last_kwargs(create_session)["json"] == {"nonce": 123456, "currency": "eth", "amount": "0.019"}
     assert last_payload(create_session)["path"] == "/api/v3/wallet/m/loan"
 
     list_session = FakeSession([loan_payload()])
@@ -147,6 +147,7 @@ def test_create_m_wallet_loan_and_history_construct_authenticated_requests() -> 
     assert loans == [MWalletLoan.model_validate(loan_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/loans"
     assert last_kwargs(list_session)["params"] == {
+        "nonce": 123456,
         "currency": "eth",
         "timestamp": 1521726960357,
         "order": "desc",
@@ -161,13 +162,13 @@ def test_m_wallet_transfer_create_and_history_construct_requests() -> None:
     assert transfer == MWalletTransfer.model_validate(transfer_payload())
     assert create_session.calls[-1]["method"] == "POST"
     assert create_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/transfer"
-    assert last_kwargs(create_session)["json"] == {"currency": "eth", "amount": "0.019", "side": "in"}
+    assert last_kwargs(create_session)["json"] == {"nonce": 123456, "currency": "eth", "amount": "0.019", "side": "in"}
 
     list_session = FakeSession([transfer_payload()])
     transfers = authenticated_client(list_session).m_wallet_transfers(currency="eth", side="in", limit=1)
     assert transfers == [MWalletTransfer.model_validate(transfer_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/transfers"
-    assert last_kwargs(list_session)["params"] == {"currency": "eth", "side": "in", "limit": 1}
+    assert last_kwargs(list_session)["params"] == {"nonce": 123456, "currency": "eth", "side": "in", "limit": 1}
 
 
 def test_m_wallet_repayment_create_and_history_construct_requests() -> None:
@@ -177,13 +178,13 @@ def test_m_wallet_repayment_create_and_history_construct_requests() -> None:
     assert repayment == MWalletRepayment.model_validate(repayment_payload())
     assert create_session.calls[-1]["method"] == "POST"
     assert create_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/repayment"
-    assert last_kwargs(create_session)["json"] == {"currency": "eth", "amount": "0.15"}
+    assert last_kwargs(create_session)["json"] == {"nonce": 123456, "currency": "eth", "amount": "0.15"}
 
     list_session = FakeSession([repayment_payload()])
     repayments = authenticated_client(list_session).m_wallet_repayments("eth", order="asc", limit=1)
     assert repayments == [MWalletRepayment.model_validate(repayment_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/repayments"
-    assert last_kwargs(list_session)["params"] == {"currency": "eth", "order": "asc", "limit": 1}
+    assert last_kwargs(list_session)["params"] == {"nonce": 123456, "currency": "eth", "order": "asc", "limit": 1}
 
 
 def test_m_wallet_liquidations_and_detail_parse_nested_payloads() -> None:
@@ -192,7 +193,7 @@ def test_m_wallet_liquidations_and_detail_parse_nested_payloads() -> None:
 
     assert liquidations == [MWalletLiquidation.model_validate(liquidation_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/liquidations"
-    assert last_kwargs(list_session)["params"] == {"limit": 1}
+    assert last_kwargs(list_session)["params"] == {"nonce": 123456, "limit": 1}
 
     detail_session = FakeSession(liquidation_detail_payload())
     detail = authenticated_client(detail_session).m_wallet_liquidation("210407080800050666")
@@ -200,7 +201,7 @@ def test_m_wallet_liquidations_and_detail_parse_nested_payloads() -> None:
     assert detail.repayments[0].principal == "0.1"
     assert detail.liquidations[0].repayment.interest == "0.05"
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/liquidation"
-    assert last_kwargs(detail_session)["params"] == {"sn": "210407080800050666"}
+    assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "sn": "210407080800050666"}
 
 
 def test_m_wallet_interests_and_ad_ratio_construct_authenticated_requests() -> None:
@@ -216,7 +217,7 @@ def test_m_wallet_interests_and_ad_ratio_construct_authenticated_requests() -> N
 
     assert interests == [MWalletInterest.model_validate(interest_payload)]
     assert interests_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/interests"
-    assert last_kwargs(interests_session)["params"] == {"currency": "eth", "limit": 1}
+    assert last_kwargs(interests_session)["params"] == {"nonce": 123456, "currency": "eth", "limit": 1}
 
     ad_ratio_payload = {"ad_ratio": "1.21", "asset_in_usdt": "2639.98128484", "debt_in_usdt": "2165.54482641"}
     ad_ratio_session = FakeSession(ad_ratio_payload)

--- a/tests/v3/test_private.py
+++ b/tests/v3/test_private.py
@@ -112,7 +112,7 @@ def test_accounts_constructs_authenticated_request_and_parses_accounts() -> None
     assert accounts == [Account(currency="twd", balance="100000.0", locked="5566.0", staked=None)]
     assert session.calls[-1]["method"] == "GET"
     assert session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/accounts"
-    assert last_kwargs(session)["params"] == {"currency": "twd"}
+    assert last_kwargs(session)["params"] == {"nonce": 123456, "currency": "twd"}
     assert last_payload(session) == {
         "nonce": 123456,
         "currency": "twd",
@@ -126,7 +126,7 @@ def test_open_closed_and_history_orders_parse_order_models() -> None:
     open_session = FakeSession([order_payload()])
     assert authenticated_client(open_session).open_orders(market="ethtwd", limit=1) == [expected_order]
     assert open_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/orders/open"
-    assert last_kwargs(open_session)["params"] == {"market": "ethtwd", "limit": 1}
+    assert last_kwargs(open_session)["params"] == {"nonce": 123456, "market": "ethtwd", "limit": 1}
 
     closed_session = FakeSession([order_payload(state="done")])
     assert authenticated_client(closed_session).closed_orders(wallet_type="m")[0].state == "done"
@@ -135,7 +135,7 @@ def test_open_closed_and_history_orders_parse_order_models() -> None:
     history_session = FakeSession([order_payload()])
     history = authenticated_client(history_session).order_history("ethtwd", from_id=10, limit=50)
     assert history == [expected_order]
-    assert last_kwargs(history_session)["params"] == {"market": "ethtwd", "from_id": 10, "limit": 50}
+    assert last_kwargs(history_session)["params"] == {"nonce": 123456, "market": "ethtwd", "from_id": 10, "limit": 50}
 
 
 def test_wallet_trades_constructs_authenticated_request_and_parses_private_trades() -> None:
@@ -160,7 +160,13 @@ def test_wallet_trades_constructs_authenticated_request_and_parses_private_trade
 
     assert trades == [PrivateTrade.model_validate(trade_payload)]
     assert session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/trades"
-    assert last_kwargs(session)["params"] == {"market": "ethtwd", "from_id": 68444, "order": "asc", "limit": 1}
+    assert last_kwargs(session)["params"] == {
+        "nonce": 123456,
+        "market": "ethtwd",
+        "from_id": 68444,
+        "order": "asc",
+        "limit": 1,
+    }
     assert last_payload(session)["path"] == "/api/v3/wallet/spot/trades"
 
 
@@ -173,7 +179,7 @@ def test_order_lookup_and_order_trades_construct_requests() -> None:
     assert order.state is OrderState.WAIT
     assert order.ord_type is OrderType.LIMIT
     assert order_session.calls[-1]["url"] == "https://example.test/api/v3/order"
-    assert last_kwargs(order_session)["params"] == {"id": 87}
+    assert last_kwargs(order_session)["params"] == {"nonce": 123456, "id": 87}
 
     trade_payload = {
         "id": 68444,
@@ -196,7 +202,7 @@ def test_order_lookup_and_order_trades_construct_requests() -> None:
 
     assert trades == [PrivateTrade.model_validate(trade_payload)]
     assert trade_session.calls[-1]["url"] == "https://example.test/api/v3/order/trades"
-    assert last_kwargs(trade_session)["params"] == {"client_oid": "client-1"}
+    assert last_kwargs(trade_session)["params"] == {"nonce": 123456, "client_oid": "client-1"}
 
 
 def test_create_and_cancel_order_send_authenticated_json_body() -> None:
@@ -214,6 +220,7 @@ def test_create_and_cancel_order_send_authenticated_json_body() -> None:
     assert create_session.calls[-1]["method"] == "POST"
     assert create_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/order"
     assert last_kwargs(create_session)["json"] == {
+        "nonce": 123456,
         "market": "ethtwd",
         "side": "buy",
         "volume": "0.2658",
@@ -227,10 +234,10 @@ def test_create_and_cancel_order_send_authenticated_json_body() -> None:
     assert authenticated_client(cancel_session).cancel_order(order_id=87).state == "cancel"
     assert cancel_session.calls[-1]["method"] == "DELETE"
     assert cancel_session.calls[-1]["url"] == "https://example.test/api/v3/order"
-    assert last_kwargs(cancel_session)["json"] == {"id": 87}
+    assert last_kwargs(cancel_session)["json"] == {"nonce": 123456, "id": 87}
 
     cancel_all_session = FakeSession([order_payload(state="cancel")])
     cancelled = authenticated_client(cancel_all_session).cancel_orders(market="ethtwd", side="buy")
     assert cancelled[0].state == "cancel"
     assert cancel_all_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/orders"
-    assert last_kwargs(cancel_all_session)["json"] == {"market": "ethtwd", "side": "buy"}
+    assert last_kwargs(cancel_all_session)["json"] == {"nonce": 123456, "market": "ethtwd", "side": "buy"}

--- a/tests/v3/test_public.py
+++ b/tests/v3/test_public.py
@@ -86,7 +86,7 @@ def test_currencies_returns_currency_models() -> None:
                 "min_borrow_amount": "0.001",
                 "networks": [
                     {
-                        "token_contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+                        "token_contract_address": None,
                         "precision": 8,
                         "id": "trc20usdt",
                         "network_protocol": "tron-trc20",


### PR DESCRIPTION
## Summary
- add opt-in public and private read-only live pytest coverage for MAX REST v3
- add pytest markers, `just live-test`, and README usage docs
- load `.env` in just and include authenticated nonce in actual request params/body for live API validation
- allow nullable currency network token contract addresses observed in live responses

## Tests
- `just`
- `just live-test`