### PR TITLE
docs: add API docstrings

### DIFF
--- a/docs/reference/v3.md
+++ b/docs/reference/v3.md
@@ -6,6 +6,8 @@ REST v3 client for the MaiCoin MAX API.
 
 ::: maicoin.v3.Client
 
+::: maicoin.v3.client.RequestSession
+
 ## Constants
 
 ::: maicoin.v3.BASE_URL

--- a/src/maicoin/v3/auth.py
+++ b/src/maicoin/v3/auth.py
@@ -1,3 +1,17 @@
+"""Authentication helpers for [MaiCoin MAX REST v3](https://max-api.maicoin.com/doc/v3.html).
+
+MAX expects each authenticated request to carry three headers:
+
+- `X-MAX-ACCESSKEY` — the API access key.
+- `X-MAX-PAYLOAD` — a base64-encoded JSON object containing `path`, `nonce`,
+  and request parameters.
+- `X-MAX-SIGNATURE` — `HMAC-SHA256(api_secret, payload)` as hex.
+
+The functions in this module produce those values. [`Client`][maicoin.v3.Client]
+uses them automatically; call them directly only if you are building requests
+outside the typed client.
+"""
+
 from __future__ import annotations
 
 import base64
@@ -10,10 +24,29 @@ import orjson
 
 
 def generate_nonce() -> int:
+    """Return the current UTC time as a millisecond UNIX nonce.
+
+    MAX rejects any nonce that is not strictly greater than the previous one
+    used by the key, so reusing this helper across processes that share an API
+    key can race. Pass a custom `nonce_factory` to [`Client`][maicoin.v3.Client]
+    if you need monotonic generation.
+    """
     return int(datetime.now(tz=UTC).timestamp() * 1000)
 
 
 def encode_payload(path: str, params: Mapping[str, object] | None = None, nonce: int | None = None) -> str:
+    """Build the base64-encoded payload that goes in the `X-MAX-PAYLOAD` header.
+
+    Args:
+        path: Request path beginning with `/`, e.g. `"/api/v3/info"`.
+        params: Request parameters merged into the payload (typically the
+            query string for GET requests, or the JSON body for POST/DELETE).
+        nonce: Millisecond nonce. Generated via [`generate_nonce`][maicoin.v3.generate_nonce]
+            when omitted.
+
+    Returns:
+        Base64-encoded JSON ready to assign to `X-MAX-PAYLOAD`.
+    """
     payload: dict[str, object] = {"nonce": generate_nonce() if nonce is None else nonce}
     if params is not None:
         payload.update(params)
@@ -24,6 +57,10 @@ def encode_payload(path: str, params: Mapping[str, object] | None = None, nonce:
 
 
 def sign_payload(api_secret: str, payload: str) -> str:
+    """Return the HMAC-SHA256 hex digest of `payload` keyed with `api_secret`.
+
+    The result is what MAX expects in the `X-MAX-SIGNATURE` header.
+    """
     return hmac.new(api_secret.encode(), payload.encode(), digestmod="sha256").hexdigest()
 
 
@@ -34,6 +71,20 @@ def build_auth_headers(
     params: Mapping[str, object] | None = None,
     nonce: int | None = None,
 ) -> dict[str, str]:
+    """Build the full set of MAX authentication headers for a request.
+
+    Args:
+        api_key: MAX API access key.
+        api_secret: MAX API secret.
+        path: Request path beginning with `/`.
+        params: Request parameters that will be sent (must match the payload
+            actually transmitted, otherwise the signature is rejected).
+        nonce: Optional millisecond nonce. Generated when omitted.
+
+    Returns:
+        A dict containing `X-MAX-ACCESSKEY`, `X-MAX-PAYLOAD`,
+        `X-MAX-SIGNATURE`, and `Content-Type: application/json`.
+    """
     payload = encode_payload(path=path, params=params, nonce=nonce)
     return {
         "X-MAX-ACCESSKEY": api_key,

--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -1,3 +1,10 @@
+"""REST v3 client for the [MaiCoin MAX](https://max-api.maicoin.com/doc/v3.html) API.
+
+Public endpoints (markets, tickers, depth, trades, kline, timestamp) need no
+credentials. Every other method is authenticated and requires `api_key` /
+`api_secret` to sign the request.
+"""
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -48,7 +55,10 @@ from maicoin.v3.models import WithdrawAddress
 from maicoin.v3.models import Withdrawal
 
 BASE_URL = "https://max-api.maicoin.com"
+"""Default MAX REST v3 base URL."""
+
 DEFAULT_TIMEOUT = 10
+"""Default per-request timeout in seconds."""
 
 
 def _compact(params: Mapping[str, object | None]) -> dict[str, object]:
@@ -56,10 +66,35 @@ def _compact(params: Mapping[str, object | None]) -> dict[str, object]:
 
 
 class RequestSession(Protocol):
+    """Minimal HTTP session protocol used by [`Client`][maicoin.v3.Client].
+
+    Anything with a `request(method, url, **kwargs) -> Response` shape works,
+    so you can swap in `httpx.Client`, a mocked session for tests, or a custom
+    transport.
+    """
+
     def request(self, method: str, url: str, **kwargs: object) -> Response: ...
 
 
 class Client:
+    """Synchronous REST v3 client for the MaiCoin MAX exchange.
+
+    Construct without credentials for public endpoints, or pass `api_key` and
+    `api_secret` to call authenticated (signed) endpoints.
+
+    Examples:
+        Public-only client:
+
+        >>> from maicoin.v3 import Client
+        >>> client = Client()
+        >>> client.ticker("btctwd")  # doctest: +SKIP
+
+        Authenticated client:
+
+        >>> client = Client(api_key="...", api_secret="...")  # doctest: +SKIP
+        >>> client.accounts()  # doctest: +SKIP
+    """
+
     def __init__(
         self,
         api_key: str | None = None,
@@ -70,6 +105,18 @@ class Client:
         session: RequestSession | None = None,
         nonce_factory: Callable[[], int] = generate_nonce,
     ) -> None:
+        """Build a REST v3 client.
+
+        Args:
+            api_key: MAX API access key. Required for authenticated endpoints.
+            api_secret: MAX API secret used to sign authenticated requests.
+            base_url: API base URL. Override for staging or test environments.
+            timeout: Per-request timeout in seconds.
+            session: Custom HTTP session implementing [`RequestSession`][maicoin.v3.client.RequestSession].
+                Defaults to a fresh `httpx.Client`.
+            nonce_factory: Callable returning a strictly increasing integer
+                nonce in milliseconds. Override in tests.
+        """
         self.api_key = api_key
         self.api_secret = api_secret
         self.base_url = base_url
@@ -85,6 +132,27 @@ class Client:
         *,
         auth: bool = False,
     ) -> object:
+        """Send a raw REST v3 request and return the parsed JSON payload.
+
+        Use this escape hatch when you need an endpoint that the typed
+        wrappers below don't cover. Auth headers, nonce injection, and error
+        handling work the same way as for the typed methods.
+
+        Args:
+            method: HTTP method, case-insensitive (e.g. `"GET"`, `"POST"`).
+            path: Request path. Leading `/` is added automatically.
+            params: Query parameters (GET) or JSON body (other methods).
+                Use `None` values to omit a key — they are dropped before sending.
+            auth: When `True`, sign the request with the configured credentials.
+
+        Returns:
+            The parsed JSON response, or `None` for empty bodies.
+
+        Raises:
+            ValueError: `auth=True` but the client has no credentials.
+            MaxHTTPError: Non-2xx HTTP response.
+            MaxAPIError: MAX-shaped error payload (`{"error": {...}}`).
+        """
         normalized_method = method.upper()
         normalized_path = path if path.startswith("/") else f"/{path}"
         url = urljoin(self.base_url, normalized_path)
@@ -126,14 +194,17 @@ class Client:
         return payload
 
     def markets(self) -> list[Market]:
+        """List all available markets (`GET /api/v3/markets`)."""
         payload = self.request("GET", "/api/v3/markets")
         return [Market.model_validate(item) for item in cast("list[object]", payload)]
 
     def currencies(self) -> list[Currency]:
+        """List all supported currencies, including network info (`GET /api/v3/currencies`)."""
         payload = self.request("GET", "/api/v3/currencies")
         return [Currency.model_validate(item) for item in cast("list[object]", payload)]
 
     def timestamp(self) -> Timestamp:
+        """Return the server-side timestamp (`GET /api/v3/timestamp`)."""
         payload = self.request("GET", "/api/v3/timestamp")
         return Timestamp.model_validate(payload)
 
@@ -145,6 +216,14 @@ class Client:
         period: int = 1,
         timestamp: int | None = None,
     ) -> list[KLine]:
+        """Fetch OHLCV candles for `market` (`GET /api/v3/k`).
+
+        Args:
+            market: Market id, e.g. `"btctwd"`.
+            limit: Number of candles to return (1-10000, default 30).
+            period: Candle period in minutes (1, 5, 15, 30, 60, 120, 240, 360, 720, 1440, 4320, 10080).
+            timestamp: Earliest UNIX timestamp (seconds) to include.
+        """
         payload = self.request(
             "GET",
             "/api/v3/k",
@@ -163,6 +242,13 @@ class Client:
         ]
 
     def depth(self, market: str, *, limit: int | None = None, sort_by_price: bool | None = None) -> Depth:
+        """Fetch the order book depth for `market` (`GET /api/v3/depth`).
+
+        Args:
+            market: Market id, e.g. `"btctwd"`.
+            limit: Maximum number of price levels per side.
+            sort_by_price: If `True`, sort each side by price.
+        """
         payload = self.request(
             "GET",
             "/api/v3/depth",
@@ -171,6 +257,7 @@ class Client:
         return Depth.model_validate(payload)
 
     def trades(self, market: str, *, timestamp: int | None = None, limit: int | None = None) -> list[PublicTrade]:
+        """Fetch recent public trades for `market` (`GET /api/v3/trades`)."""
         payload = self.request(
             "GET",
             "/api/v3/trades",
@@ -179,18 +266,27 @@ class Client:
         return [PublicTrade.model_validate(item) for item in cast("list[object]", payload)]
 
     def tickers(self, markets: Sequence[str]) -> list[Ticker]:
+        """Fetch tickers for several markets in one request (`GET /api/v3/tickers`)."""
         payload = self.request("GET", "/api/v3/tickers", params={"markets[]": list(markets)})
         return [Ticker.model_validate(item) for item in cast("list[object]", payload)]
 
     def ticker(self, market: str) -> Ticker:
+        """Fetch the ticker for a single market (`GET /api/v3/ticker`)."""
         payload = self.request("GET", "/api/v3/ticker", params={"market": market})
         return Ticker.model_validate(payload)
 
     def info(self) -> UserInfo:
+        """Return the authenticated user profile and VIP info (`GET /api/v3/info`)."""
         payload = self.request("GET", "/api/v3/info", auth=True)
         return UserInfo.model_validate(payload)
 
     def accounts(self, *, wallet_type: str = "spot", currency: str | None = None) -> list[Account]:
+        """List wallet account balances.
+
+        Args:
+            wallet_type: `"spot"` or `"m"` (M-Wallet).
+            currency: Optional filter, e.g. `"twd"`.
+        """
         payload = self.request(
             "GET",
             f"/api/v3/wallet/{wallet_type}/accounts",
@@ -209,6 +305,7 @@ class Client:
         order: str | None = None,
         limit: int | None = None,
     ) -> list[PrivateTrade]:
+        """List the authenticated user's trades for a wallet."""
         payload = self.request(
             "GET",
             f"/api/v3/wallet/{wallet_type}/trades",
@@ -228,6 +325,7 @@ class Client:
         order_by: str | None = None,
         limit: int | None = None,
     ) -> list[Order]:
+        """List the user's open orders."""
         payload = self.request(
             "GET",
             f"/api/v3/wallet/{wallet_type}/orders/open",
@@ -245,6 +343,7 @@ class Client:
         order_by: str | None = None,
         limit: int | None = None,
     ) -> list[Order]:
+        """List the user's closed (filled or cancelled) orders."""
         payload = self.request(
             "GET",
             f"/api/v3/wallet/{wallet_type}/orders/closed",
@@ -261,6 +360,10 @@ class Client:
         from_id: int | None = None,
         limit: int | None = None,
     ) -> list[Order]:
+        """Page through the full order history for a market.
+
+        Use `from_id` to seek past the last id you saw.
+        """
         payload = self.request(
             "GET",
             f"/api/v3/wallet/{wallet_type}/orders/history",
@@ -270,6 +373,7 @@ class Client:
         return [Order.model_validate(item) for item in cast("list[object]", payload)]
 
     def order(self, *, order_id: int | None = None, client_oid: str | None = None) -> Order:
+        """Fetch a single order by `order_id` or `client_oid`."""
         payload = self.request(
             "GET",
             "/api/v3/order",
@@ -291,6 +395,23 @@ class Client:
         ord_type: OrderType | str | None = None,
         group_id: int | None = None,
     ) -> Order:
+        """Place a new order.
+
+        !!! warning
+            This is a state-changing endpoint. Double-check `market`, `side`,
+            `volume`, and `price` before calling against a live account.
+
+        Args:
+            market: Market id, e.g. `"btctwd"`.
+            side: `"buy"` or `"sell"` (or [`OrderSide`][maicoin.v3.OrderSide]).
+            volume: Order amount as a decimal string.
+            wallet_type: `"spot"` or `"m"`.
+            price: Limit price. Omit for market orders.
+            client_oid: Optional client-side order id for idempotency.
+            stop_price: Trigger price for stop orders.
+            ord_type: One of [`OrderType`][maicoin.v3.OrderType] (e.g. `"limit"`, `"market"`, `"stop_limit"`).
+            group_id: Group id for OCO/grouped cancellation.
+        """
         payload = self.request(
             "POST",
             f"/api/v3/wallet/{wallet_type}/order",
@@ -311,6 +432,7 @@ class Client:
         return Order.model_validate(payload)
 
     def cancel_order(self, *, order_id: int | None = None, client_oid: str | None = None) -> Order:
+        """Cancel an order by `order_id` or `client_oid`."""
         payload = self.request(
             "DELETE",
             "/api/v3/order",
@@ -327,6 +449,7 @@ class Client:
         side: OrderSide | str | None = None,
         group_id: int | None = None,
     ) -> list[Order]:
+        """Bulk-cancel orders. Filters compose: omit them all to cancel everything in the wallet."""
         payload = self.request(
             "DELETE",
             f"/api/v3/wallet/{wallet_type}/orders",
@@ -336,6 +459,7 @@ class Client:
         return [Order.model_validate(item) for item in cast("list[object]", payload)]
 
     def order_trades(self, *, order_id: int | None = None, client_oid: str | None = None) -> list[PrivateTrade]:
+        """List the executed trades for one order."""
         payload = self.request(
             "GET",
             "/api/v3/order/trades",
@@ -345,10 +469,16 @@ class Client:
         return [PrivateTrade.model_validate(item) for item in cast("list[object]", payload)]
 
     def withdrawal(self, uuid: str) -> Withdrawal:
+        """Look up a withdrawal by its `uuid`."""
         payload = self.request("GET", "/api/v3/withdrawal", params={"uuid": uuid}, auth=True)
         return Withdrawal.model_validate(payload)
 
     def create_withdrawal(self, *, withdraw_address_uuid: str, amount: str) -> Withdrawal:
+        """Submit a crypto withdrawal to a pre-approved address.
+
+        !!! warning
+            State-changing. The address must already be whitelisted on MAX.
+        """
         payload = self.request(
             "POST",
             "/api/v3/withdrawal",
@@ -358,6 +488,11 @@ class Client:
         return Withdrawal.model_validate(payload)
 
     def create_twd_withdrawal(self, amount: str) -> Withdrawal:
+        """Submit a TWD bank withdrawal.
+
+        !!! warning
+            State-changing. The default bank account on file is debited.
+        """
         payload = self.request("POST", "/api/v3/withdrawal/twd", params={"amount": amount}, auth=True)
         return Withdrawal.model_validate(payload)
 
@@ -370,6 +505,7 @@ class Client:
         order: str | None = None,
         limit: int | None = None,
     ) -> list[Withdrawal]:
+        """List withdrawal history."""
         payload = self.request(
             "GET",
             "/api/v3/withdrawals",
@@ -387,6 +523,7 @@ class Client:
         limit: int | None = None,
         offset: int | None = None,
     ) -> list[WithdrawAddress]:
+        """List the user's whitelisted withdrawal addresses for `currency`."""
         payload = self.request(
             "GET",
             "/api/v3/withdraw_addresses",
@@ -396,6 +533,7 @@ class Client:
         return [WithdrawAddress.model_validate(item) for item in cast("list[object]", payload)]
 
     def deposit(self, *, txid: str | None = None, uuid: str | None = None) -> Deposit:
+        """Look up a deposit by `txid` or `uuid`."""
         payload = self.request("GET", "/api/v3/deposit", params=_compact({"txid": txid, "uuid": uuid}), auth=True)
         return Deposit.model_validate(payload)
 
@@ -407,6 +545,7 @@ class Client:
         order: str | None = None,
         limit: int | None = None,
     ) -> list[Deposit]:
+        """List deposit history."""
         payload = self.request(
             "GET",
             "/api/v3/deposits",
@@ -416,6 +555,7 @@ class Client:
         return [Deposit.model_validate(item) for item in cast("list[object]", payload)]
 
     def deposit_address(self, currency_version: str) -> DepositAddress:
+        """Get the deposit address for a specific currency/network version."""
         payload = self.request(
             "GET",
             "/api/v3/deposit_address",
@@ -433,6 +573,11 @@ class Client:
         order: str | None = None,
         limit: int | None = None,
     ) -> list[InternalTransfer]:
+        """List internal transfers between MAX users.
+
+        Args:
+            side: `"in"` or `"out"`.
+        """
         payload = self.request(
             "GET",
             "/api/v3/internal_transfers",
@@ -452,6 +597,7 @@ class Client:
         order: str | None = None,
         limit: int | None = None,
     ) -> list[Reward]:
+        """List reward history (referrals, mining, staking, etc.)."""
         payload = self.request(
             "GET",
             "/api/v3/rewards",
@@ -471,6 +617,7 @@ class Client:
     def fund_transaction_deposits(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[FundTransactionDeposit]:
+        """List fund-transaction deposits (off-exchange settlement)."""
         payload = self.request(
             "GET",
             "/api/v3/fund_transactions/deposits",
@@ -480,12 +627,14 @@ class Client:
         return [FundTransactionDeposit.model_validate(item) for item in cast("list[object]", payload)]
 
     def fund_transaction_deposit(self, sn: str) -> FundTransactionDeposit:
+        """Look up a fund-transaction deposit by `sn`."""
         payload = self.request("GET", "/api/v3/fund_transactions/deposit", params={"sn": sn}, auth=True)
         return FundTransactionDeposit.model_validate(payload)
 
     def fund_transaction_withdrawals(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[FundTransactionWithdrawal]:
+        """List fund-transaction withdrawals."""
         payload = self.request(
             "GET",
             "/api/v3/fund_transactions/withdrawals",
@@ -495,12 +644,14 @@ class Client:
         return [FundTransactionWithdrawal.model_validate(item) for item in cast("list[object]", payload)]
 
     def fund_transaction_withdrawal(self, sn: str) -> FundTransactionWithdrawal:
+        """Look up a fund-transaction withdrawal by `sn`."""
         payload = self.request("GET", "/api/v3/fund_transactions/withdrawal", params={"sn": sn}, auth=True)
         return FundTransactionWithdrawal.model_validate(payload)
 
     def fund_transaction_transfers(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[FundTransactionTransfer]:
+        """List fund-transaction transfers."""
         payload = self.request(
             "GET",
             "/api/v3/fund_transactions/transfers",
@@ -510,6 +661,7 @@ class Client:
         return [FundTransactionTransfer.model_validate(item) for item in cast("list[object]", payload)]
 
     def fund_transaction_transfer(self, sn: str) -> FundTransactionTransfer:
+        """Look up a fund-transaction transfer by `sn`."""
         payload = self.request("GET", "/api/v3/fund_transactions/transfer", params={"sn": sn}, auth=True)
         return FundTransactionTransfer.model_validate(payload)
 
@@ -521,6 +673,10 @@ class Client:
         from_amount: str | None = None,
         to_amount: str | None = None,
     ) -> ConvertOrder:
+        """Submit a convert order between two currencies.
+
+        Specify exactly one of `from_amount` or `to_amount`.
+        """
         payload = self.request(
             "POST",
             "/api/v3/convert",
@@ -537,12 +693,14 @@ class Client:
         return ConvertOrder.model_validate(payload)
 
     def convert(self, sn: str) -> ConvertOrder:
+        """Look up a convert order by `sn`."""
         payload = self.request("GET", "/api/v3/convert", params={"sn": sn}, auth=True)
         return ConvertOrder.model_validate(payload)
 
     def converts(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[ConvertOrder]:
+        """List convert order history."""
         payload = self.request(
             "GET",
             "/api/v3/converts",
@@ -552,6 +710,7 @@ class Client:
         return [ConvertOrder.model_validate(item) for item in cast("list[object]", payload)]
 
     def m_wallet_index_prices(self) -> dict[str, str]:
+        """Return current M-Wallet index prices keyed by market id."""
         payload = self.request("GET", "/api/v3/wallet/m/index_prices")
         return cast("dict[str, str]", payload)
 
@@ -562,6 +721,13 @@ class Client:
         start_time: int,
         end_time: int,
     ) -> list[HistoricalIndexPrice]:
+        """Fetch historical M-Wallet index prices for `market`.
+
+        Args:
+            market: Market id.
+            start_time: Inclusive start (UNIX milliseconds).
+            end_time: Inclusive end (UNIX milliseconds).
+        """
         payload = self.request(
             "GET",
             "/api/v3/wallet/m/historical_index_prices",
@@ -570,16 +736,23 @@ class Client:
         return [HistoricalIndexPrice.model_validate(item) for item in cast("list[object]", payload)]
 
     def m_wallet_limits(self) -> dict[str, str]:
+        """Return per-currency M-Wallet borrow limits."""
         payload = self.request("GET", "/api/v3/wallet/m/limits")
         return cast("dict[str, str]", payload)
 
     def m_wallet_interest_rates(self) -> dict[str, InterestRate]:
+        """Return current M-Wallet interest rates per currency."""
         payload = self.request("GET", "/api/v3/wallet/m/interest_rates")
         return {
             currency: InterestRate.model_validate(rate) for currency, rate in cast("dict[str, object]", payload).items()
         }
 
     def create_m_wallet_loan(self, *, currency: str, amount: str) -> MWalletLoan:
+        """Borrow `amount` of `currency` into the M-Wallet.
+
+        !!! warning
+            State-changing — accrues interest until repaid.
+        """
         payload = self.request(
             "POST",
             "/api/v3/wallet/m/loan",
@@ -596,6 +769,7 @@ class Client:
         order: str | None = None,
         limit: int | None = None,
     ) -> list[MWalletLoan]:
+        """List M-Wallet loans for `currency`."""
         payload = self.request(
             "GET",
             "/api/v3/wallet/m/loans",
@@ -605,6 +779,13 @@ class Client:
         return [MWalletLoan.model_validate(item) for item in cast("list[object]", payload)]
 
     def create_m_wallet_transfer(self, *, currency: str, amount: str, side: str) -> MWalletTransfer:
+        """Transfer between spot and M-Wallet.
+
+        Args:
+            currency: Currency code.
+            amount: Decimal amount as a string.
+            side: `"in"` (spot → M-Wallet) or `"out"` (M-Wallet → spot).
+        """
         payload = self.request(
             "POST",
             "/api/v3/wallet/m/transfer",
@@ -622,6 +803,7 @@ class Client:
         order: str | None = None,
         limit: int | None = None,
     ) -> list[MWalletTransfer]:
+        """List M-Wallet transfer history."""
         payload = self.request(
             "GET",
             "/api/v3/wallet/m/transfers",
@@ -633,6 +815,11 @@ class Client:
         return [MWalletTransfer.model_validate(item) for item in cast("list[object]", payload)]
 
     def create_m_wallet_repayment(self, *, currency: str, amount: str) -> MWalletRepayment:
+        """Repay an M-Wallet loan.
+
+        !!! warning
+            State-changing.
+        """
         payload = self.request(
             "POST",
             "/api/v3/wallet/m/repayment",
@@ -649,6 +836,7 @@ class Client:
         order: str | None = None,
         limit: int | None = None,
     ) -> list[MWalletRepayment]:
+        """List M-Wallet repayment history for `currency`."""
         payload = self.request(
             "GET",
             "/api/v3/wallet/m/repayments",
@@ -660,6 +848,7 @@ class Client:
     def m_wallet_liquidations(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[MWalletLiquidation]:
+        """List M-Wallet liquidation events."""
         payload = self.request(
             "GET",
             "/api/v3/wallet/m/liquidations",
@@ -669,6 +858,7 @@ class Client:
         return [MWalletLiquidation.model_validate(item) for item in cast("list[object]", payload)]
 
     def m_wallet_liquidation(self, sn: str) -> MWalletLiquidationDetail:
+        """Look up a single M-Wallet liquidation, including order/repayment details."""
         payload = self.request("GET", "/api/v3/wallet/m/liquidation", params={"sn": sn}, auth=True)
         return MWalletLiquidationDetail.model_validate(payload)
 
@@ -680,6 +870,7 @@ class Client:
         order: str | None = None,
         limit: int | None = None,
     ) -> list[MWalletInterest]:
+        """List M-Wallet interest accruals."""
         payload = self.request(
             "GET",
             "/api/v3/wallet/m/interests",
@@ -689,5 +880,6 @@ class Client:
         return [MWalletInterest.model_validate(item) for item in cast("list[object]", payload)]
 
     def m_wallet_ad_ratio(self) -> MWalletADRatio:
+        """Return the M-Wallet account debt ratio (asset-to-debt and margin level)."""
         payload = self.request("GET", "/api/v3/wallet/m/ad_ratio", auth=True)
         return MWalletADRatio.model_validate(payload)

--- a/src/maicoin/v3/errors.py
+++ b/src/maicoin/v3/errors.py
@@ -1,3 +1,5 @@
+"""Error types and response-validation helpers for the REST v3 client."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping
@@ -6,6 +8,11 @@ from typing import cast
 
 
 class Response(Protocol):
+    """Minimal HTTP response protocol used by the error helpers.
+
+    Compatible with `httpx.Response` and most session libraries.
+    """
+
     content: bytes
     status_code: int
     text: str
@@ -14,6 +21,14 @@ class Response(Protocol):
 
 
 class MaxAPIError(Exception):
+    """Raised when MAX returns a structured `{"error": ...}` payload.
+
+    Attributes:
+        status_code: HTTP status code, when known.
+        payload: Raw response body that triggered the error, useful for
+            inspecting MAX's `error.code` / `error.message` fields.
+    """
+
     def __init__(self, message: str, *, status_code: int | None = None, payload: object = None) -> None:
         super().__init__(message)
         self.status_code = status_code
@@ -21,10 +36,20 @@ class MaxAPIError(Exception):
 
 
 class MaxHTTPError(MaxAPIError):
-    pass
+    """Raised for non-2xx HTTP responses without a recognized MAX error body.
+
+    Behaves like [`MaxAPIError`][maicoin.v3.MaxAPIError] — catch it as a
+    subclass when you want to distinguish HTTP-level failures (network,
+    rate-limit, gateway) from API-level failures.
+    """
 
 
 def raise_for_response_status(response: Response) -> None:
+    """Raise [`MaxHTTPError`][maicoin.v3.MaxHTTPError] if `response` has a 4xx/5xx status.
+
+    The error message is taken from `payload["error"]`, `payload["message"]`,
+    the raw body, or `response.text`, in that order.
+    """
     status_code = response.status_code
     if status_code < 400:
         return
@@ -45,6 +70,11 @@ def raise_for_response_status(response: Response) -> None:
 
 
 def raise_for_api_error(payload: object) -> None:
+    """Raise [`MaxAPIError`][maicoin.v3.MaxAPIError] if `payload` carries an `error` key.
+
+    MAX occasionally returns 200 OK with an error body for endpoints like
+    convert and order placement. Call this after parsing the JSON body.
+    """
     if not isinstance(payload, Mapping):
         return
 

--- a/src/maicoin/ws/channel.py
+++ b/src/maicoin/ws/channel.py
@@ -1,11 +1,26 @@
+"""Channel identifiers used in WebSocket subscriptions and responses."""
+
 from enum import StrEnum
 
 
 class Channel(StrEnum):
+    """Public and private MAX WebSocket channels.
+
+    See the [MAX WebSocket docs](https://maicoin.github.io/max-websocket-docs/)
+    for the full event list emitted by each channel.
+    """
+
     BOOK = "book"
+    """Order-book snapshots and incremental updates for a market."""
     TRADE = "trade"
+    """Public trade prints for a market."""
     TICKER = "ticker"
+    """Rolling 24h ticker updates for a market."""
     USER = "user"
+    """Private user channel: orders, trades, and account balances."""
     KLINE = "kline"
+    """Candle stream at a configurable resolution."""
     MARKET_STATUS = "market_status"
+    """Global market on/off and trading-mode changes."""
     POOL_QUOTA = "pool_quota"
+    """M-Wallet borrow pool quotas, scoped by `currency`."""

--- a/src/maicoin/ws/request.py
+++ b/src/maicoin/ws/request.py
@@ -1,3 +1,5 @@
+"""WebSocket outgoing request models (subscribe, unsubscribe, auth)."""
+
 from __future__ import annotations
 
 import hmac
@@ -13,12 +15,23 @@ from maicoin.ws.subscription import Subscription
 
 
 class Action(StrEnum):
+    """Action verb sent in the `action` field of a WebSocket request."""
+
     Subscribe = "sub"
+    """Add subscriptions to the connection."""
     Authorize = "auth"
+    """Authenticate the connection so private channels become available."""
     Unsubscribe = "unsub"
+    """Remove existing subscriptions."""
 
 
 class Filter(StrEnum):
+    """Optional filters for subscription requests.
+
+    Filters narrow private channels to a specific event family, e.g. only
+    `order` updates without trade or account events.
+    """
+
     ORDER = "order"
     TRADE = "trade"
     ACCOUNT = "account"
@@ -32,17 +45,39 @@ class Filter(StrEnum):
 
 
 class Request(BaseModel):
+    """A single outbound WebSocket request.
+
+    Use the [`subscribe`][maicoin.ws.Request.subscribe],
+    [`unsubscribe`][maicoin.ws.Request.unsubscribe], and
+    [`auth`][maicoin.ws.Request.auth] class methods rather than constructing
+    `Request` directly — they fill in the correct `action`, generate `id`,
+    and (for auth) compute the HMAC signature.
+    """
+
     action: Action
+    """Verb describing what this request does."""
     id: str
+    """Client-generated request id, echoed back in the matching response."""
     api_key: str | None = Field(default=None, serialization_alias="apiKey")
+    """MAX API access key. Serialized as `apiKey`."""
     nonce: int | None = None
+    """Auth nonce in milliseconds."""
     signature: str | None = None
+    """`HMAC-SHA256(api_secret, str(nonce))` hex digest."""
     filters: list[Filter] | None = None
+    """Optional [`Filter`][maicoin.ws.Filter] list narrowing private channels."""
     subscriptions: list[Subscription] | None = None
+    """Subscriptions for `sub` requests."""
     subscription: list[Subscription] | None = None
+    """Subscriptions for `unsub` requests. Note: MAX uses the singular key here."""
 
     @classmethod
     def auth(cls, api_key: str, api_secret: str) -> Request:
+        """Build an `auth` request signed with `api_secret`.
+
+        The signature is `HMAC-SHA256(api_secret, str(nonce))` where `nonce`
+        is the current UTC time in milliseconds.
+        """
         nonce = int(datetime.now(tz=UTC).timestamp() * 1000)
 
         signature = hmac.new(api_secret.encode(), digestmod="sha256")
@@ -59,6 +94,7 @@ class Request(BaseModel):
 
     @classmethod
     def subscribe(cls, subscriptions: list[Subscription]) -> Request:
+        """Build a `sub` request adding `subscriptions` to the connection."""
         return cls(
             action=Action.Subscribe,
             id=str(uuid.uuid4()),
@@ -67,6 +103,7 @@ class Request(BaseModel):
 
     @classmethod
     def unsubscribe(cls, subscriptions: list[Subscription]) -> Request:
+        """Build an `unsub` request removing `subscriptions`."""
         return cls(
             action=Action.Unsubscribe,
             id=str(uuid.uuid4()),
@@ -74,4 +111,9 @@ class Request(BaseModel):
         )
 
     def message(self) -> str:
+        """Serialize this request as a JSON string ready to send over the socket.
+
+        Empty fields are dropped and `api_key` is rendered as `apiKey` to
+        match the MAX wire format.
+        """
         return self.model_dump_json(by_alias=True, exclude_none=True)

--- a/src/maicoin/ws/response.py
+++ b/src/maicoin/ws/response.py
@@ -22,6 +22,14 @@ from maicoin.ws.trade import Trade
 
 
 class Event(StrEnum):
+    """Event names sent in the `e` field of every MAX WebSocket response.
+
+    Snapshot events deliver the full current state on (re)subscribe; update
+    events deliver incremental changes after that. Lifecycle events
+    (`error`, `subscribed`, `unsubscribed`, `authenticated`) confirm
+    request handling.
+    """
+
     ERROR = "error"
     SUBSCRIBED = "subscribed"
     UNSUBSCRIBED = "unsubscribed"
@@ -48,30 +56,63 @@ class Event(StrEnum):
     BORROWING_UPDATE = "borrowing_update"
 
 
-# https://maicoin.github.io/max-websocket-docs/#/?id=response-key-alias
 class Response(BaseModel):
+    """A single message decoded from the MAX WebSocket connection.
+
+    The MAX wire format uses one-letter aliases (`e`, `T`, `M`, …) to keep
+    payloads small. This model exposes readable Python field names while
+    preserving the wire aliases via `validation_alias` so it parses raw MAX
+    JSON directly.
+
+    See the [MAX response key alias reference](https://maicoin.github.io/max-websocket-docs/#/?id=response-key-alias).
+    Inspect `event` to dispatch on message type, and read whichever payload
+    field matches that event (`ticker`, `trades`, `orders`, …).
+    """
+
     event: Event = Field(validation_alias="e")
+    """Event type. Drives which payload fields are populated."""
     created_at: datetime = Field(validation_alias="T")
+    """Server timestamp, converted from millisecond UNIX time."""
     id: str | None = Field(default=None, validation_alias="i")
+    """Echoed request id for `subscribed` / `unsubscribed` / `authenticated` events."""
     errors: list[str] | None = Field(default=None, validation_alias="E")
+    """Error messages for `error` events."""
     subscriptions: list[Subscription] | None = Field(default=None, validation_alias="s")
+    """Subscription list confirmed by `subscribed` / `unsubscribed`."""
     channel: Channel | None = Field(default=None, validation_alias="c")
+    """Source channel for events that carry market data."""
     balances: list[Balance] | None = Field(default=None, validation_alias="B")
+    """Balances payload for `account_*` events."""
     market: str | None = Field(default=None, validation_alias="M")
+    """Market id for market-scoped events."""
     asks: list[list[str]] | None = Field(default=None, validation_alias="a")
+    """Order-book ask levels, each `[price, volume]` (string)."""
     bids: list[list[str]] | None = Field(default=None, validation_alias="b")
+    """Order-book bid levels, each `[price, volume]` (string)."""
     first_update_id: int | None = Field(default=None, validation_alias="fi")
+    """First update id covered by an order-book diff."""
     last_update_id: int | None = Field(default=None, validation_alias="li")
+    """Last update id covered by an order-book diff."""
     version: int | None = Field(default=None, validation_alias="v")
+    """Snapshot version counter for the book."""
     orders: list[Order] | None = Field(default=None, validation_alias="o")
+    """Orders payload for `order_*` / `mwallet_order_*` events."""
     ticker: Ticker | None = Field(default=None, validation_alias="tk")
+    """Ticker payload for `ticker` events."""
     trades: list[Trade] | None = Field(default=None, validation_alias="t")
+    """Trade payload for `trade_*` events."""
     currency: str | None = Field(default=None, validation_alias="cu")
+    """Currency code for currency-scoped events."""
     kline: KLine | None = Field(default=None, validation_alias="k")
+    """Kline payload for `kline` events."""
     market_status: list[MarketStatus] | None = Field(default=None, validation_alias="ms")
+    """Market status payload for `market_status` events."""
     pool_quota: PoolQuota | None = Field(default=None, validation_alias="qta")
+    """Pool quota payload for `pool_quota` events."""
     m_wallet_ad_ratio: MWalletADRatio | None = Field(default=None, validation_alias="ad")
+    """M-Wallet account-debt ratio payload."""
     m_wallet_borrowings: list[MWalletBorrowing] | None = Field(default=None, validation_alias="db")
+    """M-Wallet borrowing payload for `borrowing_*` events."""
 
     @field_validator("created_at", mode="before")
     @classmethod

--- a/src/maicoin/ws/stream.py
+++ b/src/maicoin/ws/stream.py
@@ -1,3 +1,10 @@
+"""WebSocket stream client for the [MaiCoin MAX WebSocket API](https://maicoin.github.io/max-websocket-docs/).
+
+The client opens a single connection, queues subscription/auth requests, and
+dispatches each incoming message to every registered handler as a typed
+[`Response`][maicoin.ws.Response].
+"""
+
 from __future__ import annotations
 
 import asyncio
@@ -11,31 +18,80 @@ from maicoin.ws.response import Response
 from maicoin.ws.subscription import Subscription
 
 MAX_WS_URI = os.getenv("MAX_WS_URI", "wss://max-stream.maicoin.com/ws")
+"""WebSocket endpoint. Override with the `MAX_WS_URI` env var (e.g. for staging)."""
 
 
 class Stream:
+    """Synchronous-style wrapper around the MAX WebSocket connection.
+
+    Build the stream, call [`subscribe`][maicoin.ws.Stream.subscribe] /
+    [`add_handler`][maicoin.ws.Stream.add_handler] as many times as you like,
+    then call [`run`][maicoin.ws.Stream.run] to block on the event loop.
+
+    Examples:
+        Public channels only:
+
+        >>> from maicoin.ws import Channel, Stream, Subscription
+        >>> stream = Stream()
+        >>> stream.subscribe([Subscription(channel=Channel.TICKER, market="btcusdt")])
+        >>> stream.add_handler(lambda r: print(r.event))
+        >>> stream.run()  # doctest: +SKIP
+
+        Private channels (auth):
+
+        >>> stream = Stream.from_env()  # doctest: +SKIP
+    """
+
     requests: list[Request]
+    """Pending requests sent in order on connect (auth first if configured)."""
+
     handlers: list[Callable]
+    """Callbacks invoked with each parsed [`Response`][maicoin.ws.Response]."""
 
     def __init__(
         self,
         api_key: str | None = None,
         api_secret: str | None = None,
     ) -> None:
+        """Build a stream.
+
+        When both credentials are provided, an auth request is queued ahead of
+        any subscription requests so private channels can be used.
+
+        Args:
+            api_key: MAX API access key. Required for private channels.
+            api_secret: MAX API secret. Required for private channels.
+        """
         self.requests = []
         self.handlers = []
 
         self.auth(api_key, api_secret)
 
     def subscribe(self, subscriptions: list[Subscription]) -> None:
+        """Queue a `subscribe` request for the given list of subscriptions.
+
+        May be called multiple times; each call sends one `sub` request on
+        connect.
+        """
         self.requests += [Request.subscribe(subscriptions)]
 
     def auth(self, api_key: str | None, api_secret: str | None) -> None:
+        """Queue an `auth` request when credentials are present.
+
+        Called automatically by `__init__`; expose as a method so credentials
+        can also be added after construction. Missing credentials are silently
+        ignored — public-only streams stay unauthenticated.
+        """
         if api_key and api_secret:
             self.requests += [Request.auth(api_key, api_secret)]
 
     @classmethod
     def from_env(cls) -> Stream:
+        """Build a stream using `MAX_API_KEY` / `MAX_API_SECRET` from the environment.
+
+        Raises:
+            ValueError: Either env var is missing or empty.
+        """
         api_key = os.getenv("MAX_API_KEY")
         if not api_key:
             raise ValueError("MAX_API_KEY is not set")
@@ -47,9 +103,16 @@ class Stream:
         return cls(api_key=api_key, api_secret=api_secret)
 
     def run(self) -> None:
+        """Connect and dispatch messages until cancelled.
+
+        Wraps [`arun`][maicoin.ws.Stream.arun] in `asyncio.run`. Use
+        [`arun`][maicoin.ws.Stream.arun] directly when you already have an
+        event loop.
+        """
         asyncio.run(self.arun())
 
     async def arun(self) -> None:
+        """Async entry point: connect, send queued requests, and dispatch responses forever."""
         async with websockets.connect(MAX_WS_URI) as ws:
             for req in self.requests:
                 await ws.send(req.message())
@@ -61,4 +124,9 @@ class Stream:
                     handler(resp)
 
     def add_handler(self, handler: Callable) -> None:
+        """Register a callback invoked with each [`Response`][maicoin.ws.Response].
+
+        Handlers run in registration order. They should be cheap and
+        non-blocking — heavy work belongs in a background task or queue.
+        """
         self.handlers.append(handler)

--- a/src/maicoin/ws/subscription.py
+++ b/src/maicoin/ws/subscription.py
@@ -1,3 +1,5 @@
+"""Subscription model used by `sub` / `unsub` requests."""
+
 from __future__ import annotations
 
 from pydantic import BaseModel
@@ -6,8 +8,26 @@ from maicoin.ws.channel import Channel
 
 
 class Subscription(BaseModel):
+    """A single channel subscription.
+
+    Field semantics depend on `channel`:
+
+    - Public channels (`book`, `trade`, `ticker`, `kline`) require `market`.
+    - `book` accepts a `depth` (1, 5, 10, 20, 50).
+    - `kline` accepts a `resolution` (e.g. `"1m"`, `"5m"`).
+    - Private channels (`user`) are tied to the authenticated session and
+      ignore `market` / `depth` / `resolution`.
+    - `pool_quota` accepts `currency` for M-Wallet pool tracking.
+    - `market_status` is global and needs no extra fields.
+    """
+
     channel: Channel
+    """The channel to subscribe to."""
     market: str | None = None
+    """Market id (e.g. `"btcusdt"`) for market-scoped channels."""
     depth: int | None = None
+    """Order-book depth for `book`. Allowed values: 1, 5, 10, 20, 50."""
     resolution: str | None = None
+    """Candle resolution for `kline` (e.g. `"1m"`, `"15m"`, `"1h"`)."""
     currency: str | None = None
+    """Currency code for currency-scoped channels such as `pool_quota`."""


### PR DESCRIPTION
## Summary
- Add module, class, method, and field docstrings for REST v3 helpers/client/errors
- Document WebSocket channels, requests, responses, subscriptions, and stream helpers
- Include RequestSession in the generated v3 reference page

## Tests
- just