### PR TITLE
feat(v3)!: make REST client async-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ MAX_API_SECRET=your_secret
 ```python
 from maicoin.v3 import Client
 
-client = Client()                  # public endpoints
-client = Client(api_key=..., api_secret=...)  # private endpoints (signed)
+async with Client() as client:  # public endpoints
+    ticker = await client.ticker("btctwd")
 
-client.ticker("btctwd")
-client.accounts()
-client.request("GET", "/api/v3/...", auth=True)  # raw escape hatch
+async with Client(api_key=..., api_secret=...) as client:  # private endpoints (signed)
+    accounts = await client.accounts()
+    raw = await client.request("GET", "/api/v3/...", auth=True)  # raw escape hatch
 ```
 
 > [!WARNING]

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,8 @@ pip install maicoin
 ```python
 from maicoin.v3 import Client
 
-client = Client()
-print(client.ticker("btctwd"))
+async with Client() as client:
+    print(await client.ticker("btctwd"))
 ```
 
 ```python

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,21 +5,20 @@
 ```python
 from maicoin.v3 import Client
 
-client = Client()                                  # public-only
-client = Client(api_key=..., api_secret=...)       # private (signed)
-
-client.ticker("btctwd")
-client.markets()
-client.depth("btctwd", limit=5)
-client.kline("btctwd", period=1, limit=5)
+async with Client() as client:  # public-only
+    await client.ticker("btctwd")
+    await client.markets()
+    await client.depth("btctwd", limit=5)
+    await client.kline("btctwd", period=1, limit=5)
 ```
 
 For private calls:
 
 ```python
-client.info()
-client.accounts()
-client.open_orders(market="btctwd")
+async with Client(api_key=..., api_secret=...) as client:
+    await client.info()
+    await client.accounts()
+    await client.open_orders(market="btctwd")
 ```
 
 ## WebSocket

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -7,9 +7,21 @@
 ```python
 from maicoin.v3 import Client
 
-public = Client()
-private = Client(api_key="...", api_secret="...")
+async with Client() as public:
+    ticker = await public.ticker("btctwd")
+
+async with Client(api_key="...", api_secret="...") as private:
+    accounts = await private.accounts()
 ```
+
+For small synchronous scripts, every typed method also has an explicit `_sync` convenience wrapper:
+
+```python
+client = Client()
+ticker = client.ticker_sync("btctwd")
+```
+
+`_sync` wrappers use `asyncio.run()`, so code already running in an event loop should call the async methods directly.
 
 You can override the base URL, timeout, or HTTP session if needed:
 
@@ -22,31 +34,31 @@ client = Client(
     api_secret="...",
     base_url="https://max-api.maicoin.com",
     timeout=10,
-    session=httpx.Client(),
+    session=httpx.AsyncClient(),
 )
 ```
 
 ## Public endpoints
 
 ```python
-client.timestamp()
-client.markets()
-client.currencies()
-client.ticker("btctwd")
-client.tickers(["btctwd", "ethtwd"])
-client.depth("btctwd", limit=5)
-client.trades("btctwd", limit=10)
-client.kline("btctwd", period=1, limit=5)
+await client.timestamp()
+await client.markets()
+await client.currencies()
+await client.ticker("btctwd")
+await client.tickers(["btctwd", "ethtwd"])
+await client.depth("btctwd", limit=5)
+await client.trades("btctwd", limit=10)
+await client.kline("btctwd", period=1, limit=5)
 ```
 
 ## Private endpoints
 
 ```python
-client.info()
-client.accounts()
-client.open_orders(market="btctwd", limit=10)
-client.closed_orders(market="btctwd", limit=10)
-client.wallet_trades(limit=10)
+await client.info()
+await client.accounts()
+await client.open_orders(market="btctwd", limit=10)
+await client.closed_orders(market="btctwd", limit=10)
+await client.wallet_trades(limit=10)
 ```
 
 !!! warning "⚠️ Private methods can move money"
@@ -57,7 +69,7 @@ client.wallet_trades(limit=10)
 When you need an endpoint that the typed wrapper doesn't cover, call [`Client.request`][maicoin.v3.Client.request] directly:
 
 ```python
-client.request("GET", "/api/v3/some/endpoint", auth=True, params={"market": "btctwd"})
+await client.request("GET", "/api/v3/some/endpoint", auth=True, params={"market": "btctwd"})
 ```
 
 The raw method returns the parsed JSON payload and applies the same auth/error handling as the typed wrappers.

--- a/examples/rest.py
+++ b/examples/rest.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 from dotenv import find_dotenv
@@ -7,43 +8,45 @@ from rich import print
 from maicoin.v3 import Client
 
 
-def public_examples(client: Client) -> None:
+async def public_examples(client: Client) -> None:
     print("[bold cyan]markets[/bold cyan]")
-    print(client.markets()[:3])
+    print((await client.markets())[:3])
 
     print("[bold cyan]ticker btctwd[/bold cyan]")
-    print(client.ticker("btctwd"))
+    print(await client.ticker("btctwd"))
 
     print("[bold cyan]kline btctwd (period=1, limit=5)[/bold cyan]")
-    print(client.kline("btctwd", period=1, limit=5))
+    print(await client.kline("btctwd", period=1, limit=5))
 
     print("[bold cyan]depth btctwd (limit=5)[/bold cyan]")
-    print(client.depth("btctwd", limit=5))
+    print(await client.depth("btctwd", limit=5))
 
 
-def private_examples(client: Client) -> None:
+async def private_examples(client: Client) -> None:
     print("[bold magenta]user info[/bold magenta]")
-    print(client.info())
+    print(await client.info())
 
     print("[bold magenta]spot accounts[/bold magenta]")
-    print(client.accounts())
+    print(await client.accounts())
 
     print("[bold magenta]open orders btctwd[/bold magenta]")
-    print(client.open_orders(market="btctwd"))
+    print(await client.open_orders(market="btctwd"))
 
 
-def main() -> None:
+async def main() -> None:
     load_dotenv(find_dotenv())
 
-    public_examples(Client())
+    async with Client() as public_client:
+        await public_examples(public_client)
 
     api_key = os.environ.get("MAX_API_KEY")
     api_secret = os.environ.get("MAX_API_SECRET")
     if api_key and api_secret:
-        private_examples(Client(api_key=api_key, api_secret=api_secret))
+        async with Client(api_key=api_key, api_secret=api_secret) as private_client:
+            await private_examples(private_client)
     else:
         print("[yellow]MAX_API_KEY / MAX_API_SECRET not set — skipping private examples[/yellow]")
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -5,11 +5,15 @@ credentials. Every other method is authenticated and requires `api_key` /
 `api_secret` to sign the request.
 """
 
+# ruff: noqa: ANN401
+
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from collections.abc import Mapping
 from collections.abc import Sequence
+from typing import Any
 from typing import Protocol
 from typing import cast
 from urllib.parse import urljoin
@@ -69,15 +73,15 @@ class RequestSession(Protocol):
     """Minimal HTTP session protocol used by [`Client`][maicoin.v3.Client].
 
     Anything with a `request(method, url, **kwargs) -> Response` shape works,
-    so you can swap in `httpx.Client`, a mocked session for tests, or a custom
-    transport.
+    so you can swap in `httpx.AsyncClient`, a mocked session for tests, or a custom
+    async transport.
     """
 
-    def request(self, method: str, url: str, **kwargs: object) -> Response: ...
+    async def request(self, method: str, url: str, **kwargs: object) -> Response: ...
 
 
 class Client:
-    """Synchronous REST v3 client for the MaiCoin MAX exchange.
+    """Async-first REST v3 client for the MaiCoin MAX exchange.
 
     Construct without credentials for public endpoints, or pass `api_key` and
     `api_secret` to call authenticated (signed) endpoints.
@@ -86,13 +90,13 @@ class Client:
         Public-only client:
 
         >>> from maicoin.v3 import Client
-        >>> client = Client()
-        >>> client.ticker("btctwd")  # doctest: +SKIP
+        >>> async with Client() as client:  # doctest: +SKIP
+        ...     await client.ticker("btctwd")
 
         Authenticated client:
 
-        >>> client = Client(api_key="...", api_secret="...")  # doctest: +SKIP
-        >>> client.accounts()  # doctest: +SKIP
+        >>> async with Client(api_key="...", api_secret="...") as client:  # doctest: +SKIP
+        ...     await client.accounts()
     """
 
     def __init__(
@@ -113,7 +117,7 @@ class Client:
             base_url: API base URL. Override for staging or test environments.
             timeout: Per-request timeout in seconds.
             session: Custom HTTP session implementing [`RequestSession`][maicoin.v3.client.RequestSession].
-                Defaults to a fresh `httpx.Client`.
+                Defaults to a fresh `httpx.AsyncClient`.
             nonce_factory: Callable returning a strictly increasing integer
                 nonce in milliseconds. Override in tests.
         """
@@ -121,10 +125,239 @@ class Client:
         self.api_secret = api_secret
         self.base_url = base_url
         self.timeout = timeout
-        self.session: RequestSession = cast("RequestSession", httpx.Client()) if session is None else session
+        self.session: RequestSession = cast("RequestSession", httpx.AsyncClient()) if session is None else session
         self.nonce_factory = nonce_factory
 
-    def request(
+    async def __aenter__(self) -> Client:
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the underlying async HTTP session when it supports closing."""
+        aclose = getattr(self.session, "aclose", None)
+        if aclose is not None:
+            await aclose()
+
+    def _run_sync(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        """Run one async REST method for synchronous scripts."""
+        method = getattr(self, method_name)
+        return asyncio.run(method(*args, **kwargs))
+
+    def request_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("request", *args, **kwargs)
+
+    def markets_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("markets", *args, **kwargs)
+
+    def currencies_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("currencies", *args, **kwargs)
+
+    def timestamp_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("timestamp", *args, **kwargs)
+
+    def kline_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("kline", *args, **kwargs)
+
+    def depth_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("depth", *args, **kwargs)
+
+    def trades_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("trades", *args, **kwargs)
+
+    def tickers_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("tickers", *args, **kwargs)
+
+    def ticker_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("ticker", *args, **kwargs)
+
+    def info_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("info", *args, **kwargs)
+
+    def accounts_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("accounts", *args, **kwargs)
+
+    def wallet_trades_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("wallet_trades", *args, **kwargs)
+
+    def open_orders_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("open_orders", *args, **kwargs)
+
+    def closed_orders_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("closed_orders", *args, **kwargs)
+
+    def order_history_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("order_history", *args, **kwargs)
+
+    def order_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("order", *args, **kwargs)
+
+    def create_order_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("create_order", *args, **kwargs)
+
+    def cancel_order_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("cancel_order", *args, **kwargs)
+
+    def cancel_orders_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("cancel_orders", *args, **kwargs)
+
+    def order_trades_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("order_trades", *args, **kwargs)
+
+    def withdrawal_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("withdrawal", *args, **kwargs)
+
+    def create_withdrawal_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("create_withdrawal", *args, **kwargs)
+
+    def create_twd_withdrawal_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("create_twd_withdrawal", *args, **kwargs)
+
+    def withdrawals_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("withdrawals", *args, **kwargs)
+
+    def withdraw_addresses_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("withdraw_addresses", *args, **kwargs)
+
+    def deposit_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("deposit", *args, **kwargs)
+
+    def deposits_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("deposits", *args, **kwargs)
+
+    def deposit_address_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("deposit_address", *args, **kwargs)
+
+    def internal_transfers_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("internal_transfers", *args, **kwargs)
+
+    def rewards_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("rewards", *args, **kwargs)
+
+    def fund_transaction_deposits_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("fund_transaction_deposits", *args, **kwargs)
+
+    def fund_transaction_deposit_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("fund_transaction_deposit", *args, **kwargs)
+
+    def fund_transaction_withdrawals_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("fund_transaction_withdrawals", *args, **kwargs)
+
+    def fund_transaction_withdrawal_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("fund_transaction_withdrawal", *args, **kwargs)
+
+    def fund_transaction_transfers_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("fund_transaction_transfers", *args, **kwargs)
+
+    def fund_transaction_transfer_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("fund_transaction_transfer", *args, **kwargs)
+
+    def create_convert_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("create_convert", *args, **kwargs)
+
+    def convert_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("convert", *args, **kwargs)
+
+    def converts_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("converts", *args, **kwargs)
+
+    def m_wallet_index_prices_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("m_wallet_index_prices", *args, **kwargs)
+
+    def m_wallet_historical_index_prices_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("m_wallet_historical_index_prices", *args, **kwargs)
+
+    def m_wallet_limits_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("m_wallet_limits", *args, **kwargs)
+
+    def m_wallet_interest_rates_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("m_wallet_interest_rates", *args, **kwargs)
+
+    def create_m_wallet_loan_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("create_m_wallet_loan", *args, **kwargs)
+
+    def m_wallet_loans_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("m_wallet_loans", *args, **kwargs)
+
+    def create_m_wallet_transfer_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("create_m_wallet_transfer", *args, **kwargs)
+
+    def m_wallet_transfers_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("m_wallet_transfers", *args, **kwargs)
+
+    def create_m_wallet_repayment_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("create_m_wallet_repayment", *args, **kwargs)
+
+    def m_wallet_repayments_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("m_wallet_repayments", *args, **kwargs)
+
+    def m_wallet_liquidations_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("m_wallet_liquidations", *args, **kwargs)
+
+    def m_wallet_liquidation_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("m_wallet_liquidation", *args, **kwargs)
+
+    def m_wallet_interests_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("m_wallet_interests", *args, **kwargs)
+
+    def m_wallet_ad_ratio_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous convenience wrapper."""
+        return self._run_sync("m_wallet_ad_ratio", *args, **kwargs)
+
+    async def request(
         self,
         method: str,
         path: str,
@@ -184,7 +417,7 @@ class Client:
         else:
             kwargs["json"] = request_params
 
-        response = self.session.request(normalized_method, url, **kwargs)
+        response = await self.session.request(normalized_method, url, **kwargs)
         raise_for_response_status(response)
         if not response.content:
             return None
@@ -193,22 +426,22 @@ class Client:
         raise_for_api_error(payload)
         return payload
 
-    def markets(self) -> list[Market]:
+    async def markets(self) -> list[Market]:
         """List all available markets (`GET /api/v3/markets`)."""
-        payload = self.request("GET", "/api/v3/markets")
+        payload = await self.request("GET", "/api/v3/markets")
         return [Market.model_validate(item) for item in cast("list[object]", payload)]
 
-    def currencies(self) -> list[Currency]:
+    async def currencies(self) -> list[Currency]:
         """List all supported currencies, including network info (`GET /api/v3/currencies`)."""
-        payload = self.request("GET", "/api/v3/currencies")
+        payload = await self.request("GET", "/api/v3/currencies")
         return [Currency.model_validate(item) for item in cast("list[object]", payload)]
 
-    def timestamp(self) -> Timestamp:
+    async def timestamp(self) -> Timestamp:
         """Return the server-side timestamp (`GET /api/v3/timestamp`)."""
-        payload = self.request("GET", "/api/v3/timestamp")
+        payload = await self.request("GET", "/api/v3/timestamp")
         return Timestamp.model_validate(payload)
 
-    def kline(
+    async def kline(
         self,
         market: str,
         *,
@@ -224,7 +457,7 @@ class Client:
             period: Candle period in minutes (1, 5, 15, 30, 60, 120, 240, 360, 720, 1440, 4320, 10080).
             timestamp: Earliest UNIX timestamp (seconds) to include.
         """
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/k",
             params=_compact({"market": market, "limit": limit, "period": period, "timestamp": timestamp}),
@@ -241,7 +474,7 @@ class Client:
             for row in cast("list[Sequence[object]]", payload)
         ]
 
-    def depth(self, market: str, *, limit: int | None = None, sort_by_price: bool | None = None) -> Depth:
+    async def depth(self, market: str, *, limit: int | None = None, sort_by_price: bool | None = None) -> Depth:
         """Fetch the order book depth for `market` (`GET /api/v3/depth`).
 
         Args:
@@ -249,45 +482,45 @@ class Client:
             limit: Maximum number of price levels per side.
             sort_by_price: If `True`, sort each side by price.
         """
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/depth",
             params=_compact({"market": market, "limit": limit, "sort_by_price": sort_by_price}),
         )
         return Depth.model_validate(payload)
 
-    def trades(self, market: str, *, timestamp: int | None = None, limit: int | None = None) -> list[PublicTrade]:
+    async def trades(self, market: str, *, timestamp: int | None = None, limit: int | None = None) -> list[PublicTrade]:
         """Fetch recent public trades for `market` (`GET /api/v3/trades`)."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/trades",
             params=_compact({"market": market, "timestamp": timestamp, "limit": limit}),
         )
         return [PublicTrade.model_validate(item) for item in cast("list[object]", payload)]
 
-    def tickers(self, markets: Sequence[str]) -> list[Ticker]:
+    async def tickers(self, markets: Sequence[str]) -> list[Ticker]:
         """Fetch tickers for several markets in one request (`GET /api/v3/tickers`)."""
-        payload = self.request("GET", "/api/v3/tickers", params={"markets[]": list(markets)})
+        payload = await self.request("GET", "/api/v3/tickers", params={"markets[]": list(markets)})
         return [Ticker.model_validate(item) for item in cast("list[object]", payload)]
 
-    def ticker(self, market: str) -> Ticker:
+    async def ticker(self, market: str) -> Ticker:
         """Fetch the ticker for a single market (`GET /api/v3/ticker`)."""
-        payload = self.request("GET", "/api/v3/ticker", params={"market": market})
+        payload = await self.request("GET", "/api/v3/ticker", params={"market": market})
         return Ticker.model_validate(payload)
 
-    def info(self) -> UserInfo:
+    async def info(self) -> UserInfo:
         """Return the authenticated user profile and VIP info (`GET /api/v3/info`)."""
-        payload = self.request("GET", "/api/v3/info", auth=True)
+        payload = await self.request("GET", "/api/v3/info", auth=True)
         return UserInfo.model_validate(payload)
 
-    def accounts(self, *, wallet_type: str = "spot", currency: str | None = None) -> list[Account]:
+    async def accounts(self, *, wallet_type: str = "spot", currency: str | None = None) -> list[Account]:
         """List wallet account balances.
 
         Args:
             wallet_type: `"spot"` or `"m"` (M-Wallet).
             currency: Optional filter, e.g. `"twd"`.
         """
-        payload = self.request(
+        payload = await self.request(
             "GET",
             f"/api/v3/wallet/{wallet_type}/accounts",
             params=_compact({"currency": currency}),
@@ -295,7 +528,7 @@ class Client:
         )
         return [Account.model_validate(item) for item in cast("list[object]", payload)]
 
-    def wallet_trades(
+    async def wallet_trades(
         self,
         *,
         wallet_type: str = "spot",
@@ -306,7 +539,7 @@ class Client:
         limit: int | None = None,
     ) -> list[PrivateTrade]:
         """List the authenticated user's trades for a wallet."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             f"/api/v3/wallet/{wallet_type}/trades",
             params=_compact(
@@ -316,7 +549,7 @@ class Client:
         )
         return [PrivateTrade.model_validate(item) for item in cast("list[object]", payload)]
 
-    def open_orders(
+    async def open_orders(
         self,
         *,
         wallet_type: str = "spot",
@@ -326,7 +559,7 @@ class Client:
         limit: int | None = None,
     ) -> list[Order]:
         """List the user's open orders."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             f"/api/v3/wallet/{wallet_type}/orders/open",
             params=_compact({"market": market, "timestamp": timestamp, "order_by": order_by, "limit": limit}),
@@ -334,7 +567,7 @@ class Client:
         )
         return [Order.model_validate(item) for item in cast("list[object]", payload)]
 
-    def closed_orders(
+    async def closed_orders(
         self,
         *,
         wallet_type: str = "spot",
@@ -344,7 +577,7 @@ class Client:
         limit: int | None = None,
     ) -> list[Order]:
         """List the user's closed (filled or cancelled) orders."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             f"/api/v3/wallet/{wallet_type}/orders/closed",
             params=_compact({"market": market, "timestamp": timestamp, "order_by": order_by, "limit": limit}),
@@ -352,7 +585,7 @@ class Client:
         )
         return [Order.model_validate(item) for item in cast("list[object]", payload)]
 
-    def order_history(
+    async def order_history(
         self,
         market: str,
         *,
@@ -364,7 +597,7 @@ class Client:
 
         Use `from_id` to seek past the last id you saw.
         """
-        payload = self.request(
+        payload = await self.request(
             "GET",
             f"/api/v3/wallet/{wallet_type}/orders/history",
             params=_compact({"market": market, "from_id": from_id, "limit": limit}),
@@ -372,9 +605,9 @@ class Client:
         )
         return [Order.model_validate(item) for item in cast("list[object]", payload)]
 
-    def order(self, *, order_id: int | None = None, client_oid: str | None = None) -> Order:
+    async def order(self, *, order_id: int | None = None, client_oid: str | None = None) -> Order:
         """Fetch a single order by `order_id` or `client_oid`."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/order",
             params=_compact({"id": order_id, "client_oid": client_oid}),
@@ -382,7 +615,7 @@ class Client:
         )
         return Order.model_validate(payload)
 
-    def create_order(
+    async def create_order(
         self,
         market: str,
         side: OrderSide | str,
@@ -412,7 +645,7 @@ class Client:
             ord_type: One of [`OrderType`][maicoin.v3.OrderType] (e.g. `"limit"`, `"market"`, `"stop_limit"`).
             group_id: Group id for OCO/grouped cancellation.
         """
-        payload = self.request(
+        payload = await self.request(
             "POST",
             f"/api/v3/wallet/{wallet_type}/order",
             params=_compact(
@@ -431,9 +664,9 @@ class Client:
         )
         return Order.model_validate(payload)
 
-    def cancel_order(self, *, order_id: int | None = None, client_oid: str | None = None) -> Order:
+    async def cancel_order(self, *, order_id: int | None = None, client_oid: str | None = None) -> Order:
         """Cancel an order by `order_id` or `client_oid`."""
-        payload = self.request(
+        payload = await self.request(
             "DELETE",
             "/api/v3/order",
             params=_compact({"id": order_id, "client_oid": client_oid}),
@@ -441,7 +674,7 @@ class Client:
         )
         return Order.model_validate(payload)
 
-    def cancel_orders(
+    async def cancel_orders(
         self,
         *,
         wallet_type: str = "spot",
@@ -450,7 +683,7 @@ class Client:
         group_id: int | None = None,
     ) -> list[Order]:
         """Bulk-cancel orders. Filters compose: omit them all to cancel everything in the wallet."""
-        payload = self.request(
+        payload = await self.request(
             "DELETE",
             f"/api/v3/wallet/{wallet_type}/orders",
             params=_compact({"market": market, "side": side, "group_id": group_id}),
@@ -458,9 +691,9 @@ class Client:
         )
         return [Order.model_validate(item) for item in cast("list[object]", payload)]
 
-    def order_trades(self, *, order_id: int | None = None, client_oid: str | None = None) -> list[PrivateTrade]:
+    async def order_trades(self, *, order_id: int | None = None, client_oid: str | None = None) -> list[PrivateTrade]:
         """List the executed trades for one order."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/order/trades",
             params=_compact({"order_id": order_id, "client_oid": client_oid}),
@@ -468,18 +701,18 @@ class Client:
         )
         return [PrivateTrade.model_validate(item) for item in cast("list[object]", payload)]
 
-    def withdrawal(self, uuid: str) -> Withdrawal:
+    async def withdrawal(self, uuid: str) -> Withdrawal:
         """Look up a withdrawal by its `uuid`."""
-        payload = self.request("GET", "/api/v3/withdrawal", params={"uuid": uuid}, auth=True)
+        payload = await self.request("GET", "/api/v3/withdrawal", params={"uuid": uuid}, auth=True)
         return Withdrawal.model_validate(payload)
 
-    def create_withdrawal(self, *, withdraw_address_uuid: str, amount: str) -> Withdrawal:
+    async def create_withdrawal(self, *, withdraw_address_uuid: str, amount: str) -> Withdrawal:
         """Submit a crypto withdrawal to a pre-approved address.
 
         !!! warning
             State-changing. The address must already be whitelisted on MAX.
         """
-        payload = self.request(
+        payload = await self.request(
             "POST",
             "/api/v3/withdrawal",
             params={"withdraw_address_uuid": withdraw_address_uuid, "amount": amount},
@@ -487,16 +720,16 @@ class Client:
         )
         return Withdrawal.model_validate(payload)
 
-    def create_twd_withdrawal(self, amount: str) -> Withdrawal:
+    async def create_twd_withdrawal(self, amount: str) -> Withdrawal:
         """Submit a TWD bank withdrawal.
 
         !!! warning
             State-changing. The default bank account on file is debited.
         """
-        payload = self.request("POST", "/api/v3/withdrawal/twd", params={"amount": amount}, auth=True)
+        payload = await self.request("POST", "/api/v3/withdrawal/twd", params={"amount": amount}, auth=True)
         return Withdrawal.model_validate(payload)
 
-    def withdrawals(
+    async def withdrawals(
         self,
         *,
         currency: str | None = None,
@@ -506,7 +739,7 @@ class Client:
         limit: int | None = None,
     ) -> list[Withdrawal]:
         """List withdrawal history."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/withdrawals",
             params=_compact(
@@ -516,7 +749,7 @@ class Client:
         )
         return [Withdrawal.model_validate(item) for item in cast("list[object]", payload)]
 
-    def withdraw_addresses(
+    async def withdraw_addresses(
         self,
         currency: str,
         *,
@@ -524,7 +757,7 @@ class Client:
         offset: int | None = None,
     ) -> list[WithdrawAddress]:
         """List the user's whitelisted withdrawal addresses for `currency`."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/withdraw_addresses",
             params=_compact({"currency": currency, "limit": limit, "offset": offset}),
@@ -532,12 +765,12 @@ class Client:
         )
         return [WithdrawAddress.model_validate(item) for item in cast("list[object]", payload)]
 
-    def deposit(self, *, txid: str | None = None, uuid: str | None = None) -> Deposit:
+    async def deposit(self, *, txid: str | None = None, uuid: str | None = None) -> Deposit:
         """Look up a deposit by `txid` or `uuid`."""
-        payload = self.request("GET", "/api/v3/deposit", params=_compact({"txid": txid, "uuid": uuid}), auth=True)
+        payload = await self.request("GET", "/api/v3/deposit", params=_compact({"txid": txid, "uuid": uuid}), auth=True)
         return Deposit.model_validate(payload)
 
-    def deposits(
+    async def deposits(
         self,
         *,
         currency: str | None = None,
@@ -546,7 +779,7 @@ class Client:
         limit: int | None = None,
     ) -> list[Deposit]:
         """List deposit history."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/deposits",
             params=_compact({"currency": currency, "timestamp": timestamp, "order": order, "limit": limit}),
@@ -554,9 +787,9 @@ class Client:
         )
         return [Deposit.model_validate(item) for item in cast("list[object]", payload)]
 
-    def deposit_address(self, currency_version: str) -> DepositAddress:
+    async def deposit_address(self, currency_version: str) -> DepositAddress:
         """Get the deposit address for a specific currency/network version."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/deposit_address",
             params={"currency_version": currency_version},
@@ -564,7 +797,7 @@ class Client:
         )
         return DepositAddress.model_validate(payload)
 
-    def internal_transfers(
+    async def internal_transfers(
         self,
         side: str,
         *,
@@ -578,7 +811,7 @@ class Client:
         Args:
             side: `"in"` or `"out"`.
         """
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/internal_transfers",
             params=_compact(
@@ -588,7 +821,7 @@ class Client:
         )
         return [InternalTransfer.model_validate(item) for item in cast("list[object]", payload)]
 
-    def rewards(
+    async def rewards(
         self,
         *,
         reward_type: str | None = None,
@@ -598,7 +831,7 @@ class Client:
         limit: int | None = None,
     ) -> list[Reward]:
         """List reward history (referrals, mining, staking, etc.)."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/rewards",
             params=_compact(
@@ -614,11 +847,11 @@ class Client:
         )
         return [Reward.model_validate(item) for item in cast("list[object]", payload)]
 
-    def fund_transaction_deposits(
+    async def fund_transaction_deposits(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[FundTransactionDeposit]:
         """List fund-transaction deposits (off-exchange settlement)."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/fund_transactions/deposits",
             params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
@@ -626,16 +859,16 @@ class Client:
         )
         return [FundTransactionDeposit.model_validate(item) for item in cast("list[object]", payload)]
 
-    def fund_transaction_deposit(self, sn: str) -> FundTransactionDeposit:
+    async def fund_transaction_deposit(self, sn: str) -> FundTransactionDeposit:
         """Look up a fund-transaction deposit by `sn`."""
-        payload = self.request("GET", "/api/v3/fund_transactions/deposit", params={"sn": sn}, auth=True)
+        payload = await self.request("GET", "/api/v3/fund_transactions/deposit", params={"sn": sn}, auth=True)
         return FundTransactionDeposit.model_validate(payload)
 
-    def fund_transaction_withdrawals(
+    async def fund_transaction_withdrawals(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[FundTransactionWithdrawal]:
         """List fund-transaction withdrawals."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/fund_transactions/withdrawals",
             params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
@@ -643,16 +876,16 @@ class Client:
         )
         return [FundTransactionWithdrawal.model_validate(item) for item in cast("list[object]", payload)]
 
-    def fund_transaction_withdrawal(self, sn: str) -> FundTransactionWithdrawal:
+    async def fund_transaction_withdrawal(self, sn: str) -> FundTransactionWithdrawal:
         """Look up a fund-transaction withdrawal by `sn`."""
-        payload = self.request("GET", "/api/v3/fund_transactions/withdrawal", params={"sn": sn}, auth=True)
+        payload = await self.request("GET", "/api/v3/fund_transactions/withdrawal", params={"sn": sn}, auth=True)
         return FundTransactionWithdrawal.model_validate(payload)
 
-    def fund_transaction_transfers(
+    async def fund_transaction_transfers(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[FundTransactionTransfer]:
         """List fund-transaction transfers."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/fund_transactions/transfers",
             params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
@@ -660,12 +893,12 @@ class Client:
         )
         return [FundTransactionTransfer.model_validate(item) for item in cast("list[object]", payload)]
 
-    def fund_transaction_transfer(self, sn: str) -> FundTransactionTransfer:
+    async def fund_transaction_transfer(self, sn: str) -> FundTransactionTransfer:
         """Look up a fund-transaction transfer by `sn`."""
-        payload = self.request("GET", "/api/v3/fund_transactions/transfer", params={"sn": sn}, auth=True)
+        payload = await self.request("GET", "/api/v3/fund_transactions/transfer", params={"sn": sn}, auth=True)
         return FundTransactionTransfer.model_validate(payload)
 
-    def create_convert(
+    async def create_convert(
         self,
         *,
         from_currency: str,
@@ -677,7 +910,7 @@ class Client:
 
         Specify exactly one of `from_amount` or `to_amount`.
         """
-        payload = self.request(
+        payload = await self.request(
             "POST",
             "/api/v3/convert",
             params=_compact(
@@ -692,16 +925,16 @@ class Client:
         )
         return ConvertOrder.model_validate(payload)
 
-    def convert(self, sn: str) -> ConvertOrder:
+    async def convert(self, sn: str) -> ConvertOrder:
         """Look up a convert order by `sn`."""
-        payload = self.request("GET", "/api/v3/convert", params={"sn": sn}, auth=True)
+        payload = await self.request("GET", "/api/v3/convert", params={"sn": sn}, auth=True)
         return ConvertOrder.model_validate(payload)
 
-    def converts(
+    async def converts(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[ConvertOrder]:
         """List convert order history."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/converts",
             params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
@@ -709,12 +942,12 @@ class Client:
         )
         return [ConvertOrder.model_validate(item) for item in cast("list[object]", payload)]
 
-    def m_wallet_index_prices(self) -> dict[str, str]:
+    async def m_wallet_index_prices(self) -> dict[str, str]:
         """Return current M-Wallet index prices keyed by market id."""
-        payload = self.request("GET", "/api/v3/wallet/m/index_prices")
+        payload = await self.request("GET", "/api/v3/wallet/m/index_prices")
         return cast("dict[str, str]", payload)
 
-    def m_wallet_historical_index_prices(
+    async def m_wallet_historical_index_prices(
         self,
         market: str,
         *,
@@ -728,32 +961,32 @@ class Client:
             start_time: Inclusive start (UNIX milliseconds).
             end_time: Inclusive end (UNIX milliseconds).
         """
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/wallet/m/historical_index_prices",
             params={"market": market, "start_time": start_time, "end_time": end_time},
         )
         return [HistoricalIndexPrice.model_validate(item) for item in cast("list[object]", payload)]
 
-    def m_wallet_limits(self) -> dict[str, str]:
+    async def m_wallet_limits(self) -> dict[str, str]:
         """Return per-currency M-Wallet borrow limits."""
-        payload = self.request("GET", "/api/v3/wallet/m/limits")
+        payload = await self.request("GET", "/api/v3/wallet/m/limits")
         return cast("dict[str, str]", payload)
 
-    def m_wallet_interest_rates(self) -> dict[str, InterestRate]:
+    async def m_wallet_interest_rates(self) -> dict[str, InterestRate]:
         """Return current M-Wallet interest rates per currency."""
-        payload = self.request("GET", "/api/v3/wallet/m/interest_rates")
+        payload = await self.request("GET", "/api/v3/wallet/m/interest_rates")
         return {
             currency: InterestRate.model_validate(rate) for currency, rate in cast("dict[str, object]", payload).items()
         }
 
-    def create_m_wallet_loan(self, *, currency: str, amount: str) -> MWalletLoan:
+    async def create_m_wallet_loan(self, *, currency: str, amount: str) -> MWalletLoan:
         """Borrow `amount` of `currency` into the M-Wallet.
 
         !!! warning
             State-changing — accrues interest until repaid.
         """
-        payload = self.request(
+        payload = await self.request(
             "POST",
             "/api/v3/wallet/m/loan",
             params={"currency": currency, "amount": amount},
@@ -761,7 +994,7 @@ class Client:
         )
         return MWalletLoan.model_validate(payload)
 
-    def m_wallet_loans(
+    async def m_wallet_loans(
         self,
         currency: str,
         *,
@@ -770,7 +1003,7 @@ class Client:
         limit: int | None = None,
     ) -> list[MWalletLoan]:
         """List M-Wallet loans for `currency`."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/wallet/m/loans",
             params=_compact({"currency": currency, "timestamp": timestamp, "order": order, "limit": limit}),
@@ -778,7 +1011,7 @@ class Client:
         )
         return [MWalletLoan.model_validate(item) for item in cast("list[object]", payload)]
 
-    def create_m_wallet_transfer(self, *, currency: str, amount: str, side: str) -> MWalletTransfer:
+    async def create_m_wallet_transfer(self, *, currency: str, amount: str, side: str) -> MWalletTransfer:
         """Transfer between spot and M-Wallet.
 
         Args:
@@ -786,7 +1019,7 @@ class Client:
             amount: Decimal amount as a string.
             side: `"in"` (spot → M-Wallet) or `"out"` (M-Wallet → spot).
         """
-        payload = self.request(
+        payload = await self.request(
             "POST",
             "/api/v3/wallet/m/transfer",
             params={"currency": currency, "amount": amount, "side": side},
@@ -794,7 +1027,7 @@ class Client:
         )
         return MWalletTransfer.model_validate(payload)
 
-    def m_wallet_transfers(
+    async def m_wallet_transfers(
         self,
         *,
         currency: str,
@@ -804,7 +1037,7 @@ class Client:
         limit: int | None = None,
     ) -> list[MWalletTransfer]:
         """List M-Wallet transfer history."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/wallet/m/transfers",
             params=_compact(
@@ -814,13 +1047,13 @@ class Client:
         )
         return [MWalletTransfer.model_validate(item) for item in cast("list[object]", payload)]
 
-    def create_m_wallet_repayment(self, *, currency: str, amount: str) -> MWalletRepayment:
+    async def create_m_wallet_repayment(self, *, currency: str, amount: str) -> MWalletRepayment:
         """Repay an M-Wallet loan.
 
         !!! warning
             State-changing.
         """
-        payload = self.request(
+        payload = await self.request(
             "POST",
             "/api/v3/wallet/m/repayment",
             params={"currency": currency, "amount": amount},
@@ -828,7 +1061,7 @@ class Client:
         )
         return MWalletRepayment.model_validate(payload)
 
-    def m_wallet_repayments(
+    async def m_wallet_repayments(
         self,
         currency: str,
         *,
@@ -837,7 +1070,7 @@ class Client:
         limit: int | None = None,
     ) -> list[MWalletRepayment]:
         """List M-Wallet repayment history for `currency`."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/wallet/m/repayments",
             params=_compact({"currency": currency, "timestamp": timestamp, "order": order, "limit": limit}),
@@ -845,11 +1078,11 @@ class Client:
         )
         return [MWalletRepayment.model_validate(item) for item in cast("list[object]", payload)]
 
-    def m_wallet_liquidations(
+    async def m_wallet_liquidations(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[MWalletLiquidation]:
         """List M-Wallet liquidation events."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/wallet/m/liquidations",
             params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
@@ -857,12 +1090,12 @@ class Client:
         )
         return [MWalletLiquidation.model_validate(item) for item in cast("list[object]", payload)]
 
-    def m_wallet_liquidation(self, sn: str) -> MWalletLiquidationDetail:
+    async def m_wallet_liquidation(self, sn: str) -> MWalletLiquidationDetail:
         """Look up a single M-Wallet liquidation, including order/repayment details."""
-        payload = self.request("GET", "/api/v3/wallet/m/liquidation", params={"sn": sn}, auth=True)
+        payload = await self.request("GET", "/api/v3/wallet/m/liquidation", params={"sn": sn}, auth=True)
         return MWalletLiquidationDetail.model_validate(payload)
 
-    def m_wallet_interests(
+    async def m_wallet_interests(
         self,
         *,
         currency: str | None = None,
@@ -871,7 +1104,7 @@ class Client:
         limit: int | None = None,
     ) -> list[MWalletInterest]:
         """List M-Wallet interest accruals."""
-        payload = self.request(
+        payload = await self.request(
             "GET",
             "/api/v3/wallet/m/interests",
             params=_compact({"currency": currency, "timestamp": timestamp, "order": order, "limit": limit}),
@@ -879,7 +1112,7 @@ class Client:
         )
         return [MWalletInterest.model_validate(item) for item in cast("list[object]", payload)]
 
-    def m_wallet_ad_ratio(self) -> MWalletADRatio:
+    async def m_wallet_ad_ratio(self) -> MWalletADRatio:
         """Return the M-Wallet account debt ratio (asset-to-debt and margin level)."""
-        payload = self.request("GET", "/api/v3/wallet/m/ad_ratio", auth=True)
+        payload = await self.request("GET", "/api/v3/wallet/m/ad_ratio", auth=True)
         return MWalletADRatio.model_validate(payload)

--- a/tests/live/test_private_readonly_live.py
+++ b/tests/live/test_private_readonly_live.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.live
 
 
 def test_info(private_client: Client) -> None:
-    info = private_client.info()
+    info = private_client.info_sync()
 
     assert info.email
     assert info.level >= 0
@@ -16,14 +16,14 @@ def test_info(private_client: Client) -> None:
 
 
 def test_accounts(private_client: Client) -> None:
-    accounts = private_client.accounts()
+    accounts = private_client.accounts_sync()
 
     assert accounts
     assert all(account.currency for account in accounts)
 
 
 def test_open_orders(private_client: Client) -> None:
-    orders = private_client.open_orders(limit=1)
+    orders = private_client.open_orders_sync(limit=1)
 
     assert len(orders) <= 1
     for order in orders:
@@ -32,7 +32,7 @@ def test_open_orders(private_client: Client) -> None:
 
 
 def test_closed_orders(private_client: Client) -> None:
-    orders = private_client.closed_orders(limit=1)
+    orders = private_client.closed_orders_sync(limit=1)
 
     assert len(orders) <= 1
     for order in orders:
@@ -41,7 +41,7 @@ def test_closed_orders(private_client: Client) -> None:
 
 
 def test_wallet_trades(private_client: Client) -> None:
-    trades = private_client.wallet_trades(limit=1)
+    trades = private_client.wallet_trades_sync(limit=1)
 
     assert len(trades) <= 1
     for trade in trades:

--- a/tests/live/test_public_live.py
+++ b/tests/live/test_public_live.py
@@ -8,27 +8,27 @@ pytestmark = pytest.mark.live
 
 
 def test_timestamp(public_client: Client) -> None:
-    timestamp = public_client.timestamp()
+    timestamp = public_client.timestamp_sync()
 
     assert timestamp.timestamp > 0
 
 
 def test_markets_includes_live_market(public_client: Client, live_market: str) -> None:
-    markets = public_client.markets()
+    markets = public_client.markets_sync()
 
     assert markets
     assert any(market.id == live_market for market in markets)
 
 
 def test_currencies_returns_currency_models(public_client: Client) -> None:
-    currencies = public_client.currencies()
+    currencies = public_client.currencies_sync()
 
     assert currencies
     assert all(currency.currency for currency in currencies)
 
 
 def test_ticker(public_client: Client, live_market: str) -> None:
-    ticker = public_client.ticker(live_market)
+    ticker = public_client.ticker_sync(live_market)
 
     assert ticker.market == live_market
     assert ticker.at > 0
@@ -36,14 +36,14 @@ def test_ticker(public_client: Client, live_market: str) -> None:
 
 
 def test_tickers(public_client: Client, live_market: str) -> None:
-    tickers = public_client.tickers([live_market])
+    tickers = public_client.tickers_sync([live_market])
 
     assert len(tickers) == 1
     assert tickers[0].market == live_market
 
 
 def test_depth(public_client: Client, live_market: str) -> None:
-    depth = public_client.depth(live_market, limit=1)
+    depth = public_client.depth_sync(live_market, limit=1)
 
     assert depth.timestamp > 0
     assert len(depth.asks) <= 1
@@ -51,7 +51,7 @@ def test_depth(public_client: Client, live_market: str) -> None:
 
 
 def test_trades(public_client: Client, live_market: str) -> None:
-    trades = public_client.trades(live_market, limit=1)
+    trades = public_client.trades_sync(live_market, limit=1)
 
     assert len(trades) <= 1
     for trade in trades:
@@ -60,7 +60,7 @@ def test_trades(public_client: Client, live_market: str) -> None:
 
 
 def test_kline(public_client: Client, live_market: str) -> None:
-    klines = public_client.kline(live_market, limit=1)
+    klines = public_client.kline_sync(live_market, limit=1)
 
     assert len(klines) <= 1
     for kline in klines:

--- a/tests/v3/test_client.py
+++ b/tests/v3/test_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
 from typing import cast
 
@@ -25,10 +26,14 @@ class FakeSession:
     def __init__(self, response: FakeResponse) -> None:
         self.response = response
         self.calls: list[dict[str, object]] = []
+        self.closed = False
 
-    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
         self.calls.append({"method": method, "url": url, "kwargs": kwargs})
         return self.response
+
+    async def aclose(self) -> None:
+        self.closed = True
 
 
 def last_kwargs(session: FakeSession) -> Mapping[str, object]:
@@ -39,7 +44,7 @@ def test_get_request_sends_params_as_query_params() -> None:
     session = FakeSession(FakeResponse([{"id": "btctwd"}]))
     client = Client(base_url="https://example.test", session=session)
 
-    assert client.request("GET", "/api/v3/markets", params={"foo": "bar"}) == [{"id": "btctwd"}]
+    assert asyncio.run(client.request("GET", "/api/v3/markets", params={"foo": "bar"})) == [{"id": "btctwd"}]
 
     assert session.calls[-1]["method"] == "GET"
     assert session.calls[-1]["url"] == "https://example.test/api/v3/markets"
@@ -51,7 +56,7 @@ def test_post_request_sends_params_as_json_body() -> None:
     session = FakeSession(FakeResponse({"id": 1}))
     client = Client(base_url="https://example.test", session=session)
 
-    assert client.request("POST", "api/v3/order", params={"market": "btctwd"}) == {"id": 1}
+    assert asyncio.run(client.request("POST", "api/v3/order", params={"market": "btctwd"})) == {"id": 1}
 
     assert session.calls[-1]["method"] == "POST"
     assert session.calls[-1]["url"] == "https://example.test/api/v3/order"
@@ -63,7 +68,7 @@ def test_delete_request_sends_params_as_json_body() -> None:
     session = FakeSession(FakeResponse({"ok": True}))
     client = Client(base_url="https://example.test", session=session)
 
-    assert client.request("DELETE", "/api/v3/order", params={"id": 1}) == {"ok": True}
+    assert asyncio.run(client.request("DELETE", "/api/v3/order", params={"id": 1})) == {"ok": True}
 
     assert session.calls[-1]["method"] == "DELETE"
     assert last_kwargs(session)["json"] == {"id": 1}
@@ -80,7 +85,7 @@ def test_authenticated_request_adds_max_headers() -> None:
         nonce_factory=lambda: 123456,
     )
 
-    client.request("GET", "/api/v3/wallet/spot/accounts", params={"currency": "btc"}, auth=True)
+    asyncio.run(client.request("GET", "/api/v3/wallet/spot/accounts", params={"currency": "btc"}, auth=True))
 
     headers = cast("Mapping[str, str]", last_kwargs(session)["headers"])
     assert headers["X-MAX-ACCESSKEY"] == "key"
@@ -99,18 +104,36 @@ def test_http_error_response_raises() -> None:
     )
 
     with pytest.raises(MaxHTTPError, match="invalid nonce"):
-        client.request("GET", "/api/v3/wallet/spot/accounts")
+        asyncio.run(client.request("GET", "/api/v3/wallet/spot/accounts"))
 
 
 def test_api_error_payload_raises() -> None:
     client = Client(base_url="https://example.test", session=FakeSession(FakeResponse({"error": "bad request"})))
 
     with pytest.raises(MaxAPIError, match="bad request"):
-        client.request("GET", "/api/v3/ticker")
+        asyncio.run(client.request("GET", "/api/v3/ticker"))
 
 
 def test_authenticated_request_requires_credentials() -> None:
     client = Client(base_url="https://example.test", session=FakeSession(FakeResponse({})))
 
     with pytest.raises(ValueError, match="api_key and api_secret"):
-        client.request("GET", "/api/v3/wallet/spot/accounts", auth=True)
+        asyncio.run(client.request("GET", "/api/v3/wallet/spot/accounts", auth=True))
+
+
+def test_request_sync_wrapper_runs_async_request() -> None:
+    session = FakeSession(FakeResponse({"ok": True}))
+    client = Client(base_url="https://example.test", session=session)
+
+    assert client.request_sync("GET", "/api/v3/ping") == {"ok": True}
+    assert session.calls[-1]["url"] == "https://example.test/api/v3/ping"
+
+
+def test_async_context_manager_closes_session() -> None:
+    async def run() -> FakeSession:
+        session = FakeSession(FakeResponse({}))
+        async with Client(session=session):
+            assert not session.closed
+        return session
+
+    assert asyncio.run(run()).closed

--- a/tests/v3/test_convert.py
+++ b/tests/v3/test_convert.py
@@ -25,7 +25,7 @@ class FakeSession:
         self.response = FakeResponse(payload)
         self.calls: list[dict[str, object]] = []
 
-    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
         self.calls.append({"method": method, "url": url, "kwargs": kwargs})
         return self.response
 
@@ -68,7 +68,7 @@ def convert_payload(**overrides: object) -> dict[str, object]:
 
 def test_create_convert_constructs_authenticated_post_and_parses_payload() -> None:
     session = FakeSession(convert_payload())
-    convert = authenticated_client(session).create_convert(
+    convert = authenticated_client(session).create_convert_sync(
         from_currency="btc",
         to_currency="usdt",
         from_amount="0.01",
@@ -88,7 +88,7 @@ def test_create_convert_constructs_authenticated_post_and_parses_payload() -> No
 
 def test_convert_detail_constructs_authenticated_get_and_parses_payload() -> None:
     session = FakeSession(convert_payload())
-    convert = authenticated_client(session).convert("6322d9bd-736b-4f19-b862-829e75cae1ce")
+    convert = authenticated_client(session).convert_sync("6322d9bd-736b-4f19-b862-829e75cae1ce")
 
     assert convert.sn == "6322d9bd-736b-4f19-b862-829e75cae1ce"
     assert session.calls[-1]["method"] == "GET"
@@ -98,7 +98,7 @@ def test_convert_detail_constructs_authenticated_get_and_parses_payload() -> Non
 
 def test_converts_constructs_authenticated_get_and_parses_list() -> None:
     session = FakeSession([convert_payload()])
-    converts = authenticated_client(session).converts(timestamp=1704937708, order="desc", limit=1)
+    converts = authenticated_client(session).converts_sync(timestamp=1704937708, order="desc", limit=1)
 
     assert converts == [ConvertOrder.model_validate(convert_payload())]
     assert session.calls[-1]["method"] == "GET"

--- a/tests/v3/test_funds.py
+++ b/tests/v3/test_funds.py
@@ -33,7 +33,7 @@ class FakeSession:
         self.response = FakeResponse(payload)
         self.calls: list[dict[str, object]] = []
 
-    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
         self.calls.append({"method": method, "url": url, "kwargs": kwargs})
         return self.response
 
@@ -147,14 +147,14 @@ def fund_transfer_payload(**overrides: object) -> dict[str, object]:
 
 def test_withdrawal_methods_construct_authenticated_requests_and_parse_payloads() -> None:
     detail_session = FakeSession(withdrawal_payload())
-    withdrawal = authenticated_client(detail_session).withdrawal("18022603540001")
+    withdrawal = authenticated_client(detail_session).withdrawal_sync("18022603540001")
 
     assert withdrawal == Withdrawal.model_validate(withdrawal_payload())
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/withdrawal"
     assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "uuid": "18022603540001"}
 
     create_session = FakeSession(withdrawal_payload())
-    authenticated_client(create_session).create_withdrawal(withdraw_address_uuid="addr-1", amount="0.019")
+    authenticated_client(create_session).create_withdrawal_sync(withdraw_address_uuid="addr-1", amount="0.019")
     assert create_session.calls[-1]["method"] == "POST"
     assert last_kwargs(create_session)["json"] == {
         "nonce": 123456,
@@ -164,14 +164,14 @@ def test_withdrawal_methods_construct_authenticated_requests_and_parse_payloads(
     assert last_payload(create_session)["path"] == "/api/v3/withdrawal"
 
     twd_session = FakeSession(withdrawal_payload(currency="twd", network_protocol=None, amount="100"))
-    authenticated_client(twd_session).create_twd_withdrawal("100")
+    authenticated_client(twd_session).create_twd_withdrawal_sync("100")
     assert twd_session.calls[-1]["url"] == "https://example.test/api/v3/withdrawal/twd"
     assert last_kwargs(twd_session)["json"] == {"nonce": 123456, "amount": "100"}
 
 
 def test_withdrawals_and_withdraw_addresses_parse_lists() -> None:
     withdrawals_session = FakeSession([withdrawal_payload()])
-    withdrawals = authenticated_client(withdrawals_session).withdrawals(currency="usdt", state="done", limit=1)
+    withdrawals = authenticated_client(withdrawals_session).withdrawals_sync(currency="usdt", state="done", limit=1)
 
     assert withdrawals == [Withdrawal.model_validate(withdrawal_payload())]
     assert withdrawals_session.calls[-1]["url"] == "https://example.test/api/v3/withdrawals"
@@ -194,7 +194,7 @@ def test_withdrawals_and_withdraw_addresses_parse_lists() -> None:
         "network_congested": False,
     }
     address_session = FakeSession([address_payload])
-    addresses = authenticated_client(address_session).withdraw_addresses("usdt", limit=10, offset=20)
+    addresses = authenticated_client(address_session).withdraw_addresses_sync("usdt", limit=10, offset=20)
 
     assert addresses == [WithdrawAddress.model_validate(address_payload)]
     assert address_session.calls[-1]["url"] == "https://example.test/api/v3/withdraw_addresses"
@@ -203,14 +203,14 @@ def test_withdrawals_and_withdraw_addresses_parse_lists() -> None:
 
 def test_deposit_methods_construct_authenticated_requests_and_parse_payloads() -> None:
     detail_session = FakeSession(deposit_payload())
-    deposit = authenticated_client(detail_session).deposit(uuid="18022603540001")
+    deposit = authenticated_client(detail_session).deposit_sync(uuid="18022603540001")
 
     assert deposit == Deposit.model_validate(deposit_payload())
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/deposit"
     assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "uuid": "18022603540001"}
 
     deposits_session = FakeSession([deposit_payload()])
-    deposits = authenticated_client(deposits_session).deposits(currency="usdt", order="asc", limit=1)
+    deposits = authenticated_client(deposits_session).deposits_sync(currency="usdt", order="asc", limit=1)
     assert deposits == [Deposit.model_validate(deposit_payload())]
     assert last_kwargs(deposits_session)["params"] == {"nonce": 123456, "currency": "usdt", "order": "asc", "limit": 1}
 
@@ -221,7 +221,7 @@ def test_deposit_methods_construct_authenticated_requests_and_parse_payloads() -
         "address": "TU91BoeyrqW9MKaiRPDiE6z7UecK2n2Hze",
     }
     address_session = FakeSession(address_payload)
-    address = authenticated_client(address_session).deposit_address("trc20usdt")
+    address = authenticated_client(address_session).deposit_address_sync("trc20usdt")
     assert address == DepositAddress.model_validate(address_payload)
     assert address_session.calls[-1]["url"] == "https://example.test/api/v3/deposit_address"
     assert last_kwargs(address_session)["params"] == {"nonce": 123456, "currency_version": "trc20usdt"}
@@ -238,7 +238,7 @@ def test_internal_transfers_and_rewards_construct_requests_and_parse_payloads() 
         "state": "done",
     }
     transfer_session = FakeSession([transfer_payload])
-    transfers = authenticated_client(transfer_session).internal_transfers("in", currency="eth", limit=1)
+    transfers = authenticated_client(transfer_session).internal_transfers_sync("in", currency="eth", limit=1)
 
     assert transfers == [InternalTransfer.model_validate(transfer_payload)]
     assert transfers[0].from_ == "pr***@***.com"
@@ -253,7 +253,7 @@ def test_internal_transfers_and_rewards_construct_requests_and_parse_payloads() 
         "note": "2018-11-13 Holding Reward",
     }
     reward_session = FakeSession([reward_payload])
-    rewards = authenticated_client(reward_session).rewards(reward_type="airdrop_reward", limit=1)
+    rewards = authenticated_client(reward_session).rewards_sync(reward_type="airdrop_reward", limit=1)
 
     assert rewards == [Reward.model_validate(reward_payload)]
     assert reward_session.calls[-1]["url"] == "https://example.test/api/v3/rewards"
@@ -262,7 +262,7 @@ def test_internal_transfers_and_rewards_construct_requests_and_parse_payloads() 
 
 def test_fund_transaction_deposit_methods_parse_list_and_detail() -> None:
     list_session = FakeSession([fund_deposit_payload()])
-    deposits = authenticated_client(list_session).fund_transaction_deposits(
+    deposits = authenticated_client(list_session).fund_transaction_deposits_sync(
         timestamp=1521726960123, order="desc", limit=1
     )
 
@@ -277,28 +277,29 @@ def test_fund_transaction_deposit_methods_parse_list_and_detail() -> None:
     }
 
     detail_session = FakeSession(fund_deposit_payload())
-    assert authenticated_client(detail_session).fund_transaction_deposit("18022603540001").sn == "18022603540001"
+    assert authenticated_client(detail_session).fund_transaction_deposit_sync("18022603540001").sn == "18022603540001"
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/deposit"
     assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "sn": "18022603540001"}
 
 
 def test_fund_transaction_withdrawal_methods_parse_list_and_detail() -> None:
     list_session = FakeSession([fund_withdrawal_payload()])
-    withdrawals = authenticated_client(list_session).fund_transaction_withdrawals(limit=1)
+    withdrawals = authenticated_client(list_session).fund_transaction_withdrawals_sync(limit=1)
 
     assert withdrawals == [FundTransactionWithdrawal.model_validate(fund_withdrawal_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/withdrawals"
     assert last_kwargs(list_session)["params"] == {"nonce": 123456, "limit": 1}
 
     detail_session = FakeSession(fund_withdrawal_payload())
-    assert authenticated_client(detail_session).fund_transaction_withdrawal("18022603540001").sn == "18022603540001"
+    withdrawal = authenticated_client(detail_session).fund_transaction_withdrawal_sync("18022603540001")
+    assert withdrawal.sn == "18022603540001"
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/withdrawal"
     assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "sn": "18022603540001"}
 
 
 def test_fund_transaction_transfer_methods_parse_list_and_detail() -> None:
     list_session = FakeSession([fund_transfer_payload()])
-    transfers = authenticated_client(list_session).fund_transaction_transfers(limit=1)
+    transfers = authenticated_client(list_session).fund_transaction_transfers_sync(limit=1)
 
     assert transfers == [FundTransactionTransfer.model_validate(fund_transfer_payload())]
     assert transfers[0].from_.wallet_type == "spot"
@@ -306,6 +307,6 @@ def test_fund_transaction_transfer_methods_parse_list_and_detail() -> None:
     assert last_kwargs(list_session)["params"] == {"nonce": 123456, "limit": 1}
 
     detail_session = FakeSession(fund_transfer_payload())
-    assert authenticated_client(detail_session).fund_transaction_transfer("18022603540001").sn == "18022603540001"
+    assert authenticated_client(detail_session).fund_transaction_transfer_sync("18022603540001").sn == "18022603540001"
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/transfer"
     assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "sn": "18022603540001"}

--- a/tests/v3/test_m_wallet_private.py
+++ b/tests/v3/test_m_wallet_private.py
@@ -31,7 +31,7 @@ class FakeSession:
         self.response = FakeResponse(payload)
         self.calls: list[dict[str, object]] = []
 
-    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
         self.calls.append({"method": method, "url": url, "kwargs": kwargs})
         return self.response
 
@@ -134,7 +134,7 @@ def liquidation_detail_payload() -> dict[str, object]:
 
 def test_create_m_wallet_loan_and_history_construct_authenticated_requests() -> None:
     create_session = FakeSession(loan_payload())
-    loan = authenticated_client(create_session).create_m_wallet_loan(currency="eth", amount="0.019")
+    loan = authenticated_client(create_session).create_m_wallet_loan_sync(currency="eth", amount="0.019")
 
     assert loan == MWalletLoan.model_validate(loan_payload())
     assert create_session.calls[-1]["method"] == "POST"
@@ -143,7 +143,9 @@ def test_create_m_wallet_loan_and_history_construct_authenticated_requests() -> 
     assert last_payload(create_session)["path"] == "/api/v3/wallet/m/loan"
 
     list_session = FakeSession([loan_payload()])
-    loans = authenticated_client(list_session).m_wallet_loans("eth", timestamp=1521726960357, order="desc", limit=1)
+    loans = authenticated_client(list_session).m_wallet_loans_sync(
+        "eth", timestamp=1521726960357, order="desc", limit=1
+    )
     assert loans == [MWalletLoan.model_validate(loan_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/loans"
     assert last_kwargs(list_session)["params"] == {
@@ -157,7 +159,9 @@ def test_create_m_wallet_loan_and_history_construct_authenticated_requests() -> 
 
 def test_m_wallet_transfer_create_and_history_construct_requests() -> None:
     create_session = FakeSession(transfer_payload())
-    transfer = authenticated_client(create_session).create_m_wallet_transfer(currency="eth", amount="0.019", side="in")
+    transfer = authenticated_client(create_session).create_m_wallet_transfer_sync(
+        currency="eth", amount="0.019", side="in"
+    )
 
     assert transfer == MWalletTransfer.model_validate(transfer_payload())
     assert create_session.calls[-1]["method"] == "POST"
@@ -165,7 +169,7 @@ def test_m_wallet_transfer_create_and_history_construct_requests() -> None:
     assert last_kwargs(create_session)["json"] == {"nonce": 123456, "currency": "eth", "amount": "0.019", "side": "in"}
 
     list_session = FakeSession([transfer_payload()])
-    transfers = authenticated_client(list_session).m_wallet_transfers(currency="eth", side="in", limit=1)
+    transfers = authenticated_client(list_session).m_wallet_transfers_sync(currency="eth", side="in", limit=1)
     assert transfers == [MWalletTransfer.model_validate(transfer_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/transfers"
     assert last_kwargs(list_session)["params"] == {"nonce": 123456, "currency": "eth", "side": "in", "limit": 1}
@@ -173,7 +177,7 @@ def test_m_wallet_transfer_create_and_history_construct_requests() -> None:
 
 def test_m_wallet_repayment_create_and_history_construct_requests() -> None:
     create_session = FakeSession(repayment_payload())
-    repayment = authenticated_client(create_session).create_m_wallet_repayment(currency="eth", amount="0.15")
+    repayment = authenticated_client(create_session).create_m_wallet_repayment_sync(currency="eth", amount="0.15")
 
     assert repayment == MWalletRepayment.model_validate(repayment_payload())
     assert create_session.calls[-1]["method"] == "POST"
@@ -181,7 +185,7 @@ def test_m_wallet_repayment_create_and_history_construct_requests() -> None:
     assert last_kwargs(create_session)["json"] == {"nonce": 123456, "currency": "eth", "amount": "0.15"}
 
     list_session = FakeSession([repayment_payload()])
-    repayments = authenticated_client(list_session).m_wallet_repayments("eth", order="asc", limit=1)
+    repayments = authenticated_client(list_session).m_wallet_repayments_sync("eth", order="asc", limit=1)
     assert repayments == [MWalletRepayment.model_validate(repayment_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/repayments"
     assert last_kwargs(list_session)["params"] == {"nonce": 123456, "currency": "eth", "order": "asc", "limit": 1}
@@ -189,14 +193,14 @@ def test_m_wallet_repayment_create_and_history_construct_requests() -> None:
 
 def test_m_wallet_liquidations_and_detail_parse_nested_payloads() -> None:
     list_session = FakeSession([liquidation_payload()])
-    liquidations = authenticated_client(list_session).m_wallet_liquidations(limit=1)
+    liquidations = authenticated_client(list_session).m_wallet_liquidations_sync(limit=1)
 
     assert liquidations == [MWalletLiquidation.model_validate(liquidation_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/liquidations"
     assert last_kwargs(list_session)["params"] == {"nonce": 123456, "limit": 1}
 
     detail_session = FakeSession(liquidation_detail_payload())
-    detail = authenticated_client(detail_session).m_wallet_liquidation("210407080800050666")
+    detail = authenticated_client(detail_session).m_wallet_liquidation_sync("210407080800050666")
     assert detail == MWalletLiquidationDetail.model_validate(liquidation_detail_payload())
     assert detail.repayments[0].principal == "0.1"
     assert detail.liquidations[0].repayment.interest == "0.05"
@@ -213,7 +217,7 @@ def test_m_wallet_interests_and_ad_ratio_construct_authenticated_requests() -> N
         "created_at": 1521726960123,
     }
     interests_session = FakeSession([interest_payload])
-    interests = authenticated_client(interests_session).m_wallet_interests(currency="eth", limit=1)
+    interests = authenticated_client(interests_session).m_wallet_interests_sync(currency="eth", limit=1)
 
     assert interests == [MWalletInterest.model_validate(interest_payload)]
     assert interests_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/interests"
@@ -221,7 +225,7 @@ def test_m_wallet_interests_and_ad_ratio_construct_authenticated_requests() -> N
 
     ad_ratio_payload = {"ad_ratio": "1.21", "asset_in_usdt": "2639.98128484", "debt_in_usdt": "2165.54482641"}
     ad_ratio_session = FakeSession(ad_ratio_payload)
-    ad_ratio = authenticated_client(ad_ratio_session).m_wallet_ad_ratio()
+    ad_ratio = authenticated_client(ad_ratio_session).m_wallet_ad_ratio_sync()
     assert ad_ratio == MWalletADRatio.model_validate(ad_ratio_payload)
     assert ad_ratio_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/ad_ratio"
     assert last_payload(ad_ratio_session) == {"nonce": 123456, "path": "/api/v3/wallet/m/ad_ratio"}

--- a/tests/v3/test_private.py
+++ b/tests/v3/test_private.py
@@ -31,7 +31,7 @@ class FakeSession:
         self.response = FakeResponse(payload)
         self.calls: list[dict[str, object]] = []
 
-    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
         self.calls.append({"method": method, "url": url, "kwargs": kwargs})
         return self.response
 
@@ -95,7 +95,7 @@ def test_info_constructs_authenticated_request_and_parses_user_info() -> None:
         "next_vip_level": None,
     }
     session = FakeSession(payload)
-    info = authenticated_client(session).info()
+    info = authenticated_client(session).info_sync()
 
     assert info == UserInfo.model_validate(payload)
     assert session.calls[-1]["method"] == "GET"
@@ -107,7 +107,7 @@ def test_accounts_constructs_authenticated_request_and_parses_accounts() -> None
     session = FakeSession([{"currency": "twd", "balance": "100000.0", "locked": "5566.0", "staked": None}])
     client = authenticated_client(session)
 
-    accounts = client.accounts(currency="twd")
+    accounts = client.accounts_sync(currency="twd")
 
     assert accounts == [Account(currency="twd", balance="100000.0", locked="5566.0", staked=None)]
     assert session.calls[-1]["method"] == "GET"
@@ -124,16 +124,16 @@ def test_open_closed_and_history_orders_parse_order_models() -> None:
     expected_order = Order.model_validate(order_payload())
 
     open_session = FakeSession([order_payload()])
-    assert authenticated_client(open_session).open_orders(market="ethtwd", limit=1) == [expected_order]
+    assert authenticated_client(open_session).open_orders_sync(market="ethtwd", limit=1) == [expected_order]
     assert open_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/orders/open"
     assert last_kwargs(open_session)["params"] == {"nonce": 123456, "market": "ethtwd", "limit": 1}
 
     closed_session = FakeSession([order_payload(state="done")])
-    assert authenticated_client(closed_session).closed_orders(wallet_type="m")[0].state == "done"
+    assert authenticated_client(closed_session).closed_orders_sync(wallet_type="m")[0].state == "done"
     assert closed_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/orders/closed"
 
     history_session = FakeSession([order_payload()])
-    history = authenticated_client(history_session).order_history("ethtwd", from_id=10, limit=50)
+    history = authenticated_client(history_session).order_history_sync("ethtwd", from_id=10, limit=50)
     assert history == [expected_order]
     assert last_kwargs(history_session)["params"] == {"nonce": 123456, "market": "ethtwd", "from_id": 10, "limit": 50}
 
@@ -156,7 +156,7 @@ def test_wallet_trades_constructs_authenticated_request_and_parses_private_trade
         "created_at": 1521726960357,
     }
     session = FakeSession([trade_payload])
-    trades = authenticated_client(session).wallet_trades(market="ethtwd", from_id=68444, order="asc", limit=1)
+    trades = authenticated_client(session).wallet_trades_sync(market="ethtwd", from_id=68444, order="asc", limit=1)
 
     assert trades == [PrivateTrade.model_validate(trade_payload)]
     assert session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/trades"
@@ -172,7 +172,7 @@ def test_wallet_trades_constructs_authenticated_request_and_parses_private_trade
 
 def test_order_lookup_and_order_trades_construct_requests() -> None:
     order_session = FakeSession(order_payload())
-    order = authenticated_client(order_session).order(order_id=87)
+    order = authenticated_client(order_session).order_sync(order_id=87)
 
     assert order.id == 87
     assert order.side is OrderSide.BUY
@@ -198,7 +198,7 @@ def test_order_lookup_and_order_trades_construct_requests() -> None:
         "created_at": 1521726960357,
     }
     trade_session = FakeSession([trade_payload])
-    trades = authenticated_client(trade_session).order_trades(client_oid="client-1")
+    trades = authenticated_client(trade_session).order_trades_sync(client_oid="client-1")
 
     assert trades == [PrivateTrade.model_validate(trade_payload)]
     assert trade_session.calls[-1]["url"] == "https://example.test/api/v3/order/trades"
@@ -207,7 +207,7 @@ def test_order_lookup_and_order_trades_construct_requests() -> None:
 
 def test_create_and_cancel_order_send_authenticated_json_body() -> None:
     create_session = FakeSession(order_payload())
-    created = authenticated_client(create_session).create_order(
+    created = authenticated_client(create_session).create_order_sync(
         "ethtwd",
         OrderSide.BUY,
         "0.2658",
@@ -231,13 +231,13 @@ def test_create_and_cancel_order_send_authenticated_json_body() -> None:
     assert last_payload(create_session)["path"] == "/api/v3/wallet/spot/order"
 
     cancel_session = FakeSession(order_payload(state="cancel"))
-    assert authenticated_client(cancel_session).cancel_order(order_id=87).state == "cancel"
+    assert authenticated_client(cancel_session).cancel_order_sync(order_id=87).state == "cancel"
     assert cancel_session.calls[-1]["method"] == "DELETE"
     assert cancel_session.calls[-1]["url"] == "https://example.test/api/v3/order"
     assert last_kwargs(cancel_session)["json"] == {"nonce": 123456, "id": 87}
 
     cancel_all_session = FakeSession([order_payload(state="cancel")])
-    cancelled = authenticated_client(cancel_all_session).cancel_orders(market="ethtwd", side="buy")
+    cancelled = authenticated_client(cancel_all_session).cancel_orders_sync(market="ethtwd", side="buy")
     assert cancelled[0].state == "cancel"
     assert cancel_all_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/orders"
     assert last_kwargs(cancel_all_session)["json"] == {"nonce": 123456, "market": "ethtwd", "side": "buy"}

--- a/tests/v3/test_public.py
+++ b/tests/v3/test_public.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import Any
 from typing import cast
 
 from maicoin.v3 import Client
@@ -27,7 +28,7 @@ class FakeSession:
         self.response = FakeResponse(payload)
         self.calls: list[dict[str, object]] = []
 
-    def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
         self.calls.append({"method": method, "url": url, "kwargs": kwargs})
         return self.response
 
@@ -55,7 +56,7 @@ def test_markets_returns_market_models() -> None:
     )
     client = Client(base_url="https://example.test", session=session)
 
-    markets = client.markets()
+    markets = cast(Any, client.markets_sync)()
 
     assert markets == [
         Market(
@@ -105,7 +106,7 @@ def test_currencies_returns_currency_models() -> None:
     )
     client = Client(base_url="https://example.test", session=session)
 
-    currencies = client.currencies()
+    currencies = cast(Any, client.currencies_sync)()
 
     assert currencies[0].currency == "usdt"
     assert currencies[0].networks[0].id == "trc20usdt"
@@ -115,14 +116,14 @@ def test_currencies_returns_currency_models() -> None:
 def test_timestamp_returns_timestamp_model() -> None:
     client = Client(base_url="https://example.test", session=FakeSession({"timestamp": 1678766175}))
 
-    assert client.timestamp().timestamp == 1678766175
+    assert cast(Any, client.timestamp_sync)().timestamp == 1678766175
 
 
 def test_kline_constructs_params_and_parses_rows() -> None:
     session = FakeSession([[1678766100, "1", "2", "0.5", "1.5", "42"]])
     client = Client(base_url="https://example.test", session=session)
 
-    klines = client.kline("btctwd", limit=1, period=5, timestamp=1678766100)
+    klines = cast(Any, client.kline_sync)("btctwd", limit=1, period=5, timestamp=1678766100)
 
     assert klines == [KLine(timestamp=1678766100, open="1", high="2", low="0.5", close="1.5", volume="42")]
     assert last_params(session) == {"market": "btctwd", "limit": 1, "period": 5, "timestamp": 1678766100}
@@ -140,7 +141,7 @@ def test_depth_constructs_params_and_parses_depth() -> None:
     )
     client = Client(base_url="https://example.test", session=session)
 
-    depth = client.depth("btctwd", limit=1, sort_by_price=True)
+    depth = cast(Any, client.depth_sync)("btctwd", limit=1, sort_by_price=True)
 
     assert depth == Depth(
         timestamp=1778249163,
@@ -168,7 +169,7 @@ def test_trades_constructs_params_and_parses_trades() -> None:
     )
     client = Client(base_url="https://example.test", session=session)
 
-    trades = client.trades("ethtwd", timestamp=1521726960357, limit=1)
+    trades = cast(Any, client.trades_sync)("ethtwd", timestamp=1521726960357, limit=1)
 
     assert trades[0].id == 68444
     assert trades[0].side == "bid"
@@ -194,7 +195,7 @@ def test_tickers_uses_bracket_array_param_and_parses_tickers() -> None:
     session = FakeSession([ticker_payload])
     client = Client(base_url="https://example.test", session=session)
 
-    tickers = client.tickers(["btctwd", "ethusdt"])
+    tickers = cast(Any, client.tickers_sync)(["btctwd", "ethusdt"])
 
     assert tickers == [Ticker.model_validate(ticker_payload)]
     assert last_params(session) == {"markets[]": ["btctwd", "ethusdt"]}
@@ -220,21 +221,28 @@ def test_ticker_constructs_params_and_parses_ticker() -> None:
     )
     client = Client(base_url="https://example.test", session=session)
 
-    ticker = client.ticker("btctwd")
+    ticker = cast(Any, client.ticker_sync)("btctwd")
 
     assert ticker.market == "btctwd"
     assert last_params(session) == {"market": "btctwd"}
 
 
 def test_m_wallet_public_methods_parse_payloads() -> None:
-    assert Client(session=FakeSession({"btcusdt": "79848.60666667"})).m_wallet_index_prices() == {
+    assert cast(Any, Client(session=FakeSession({"btcusdt": "79848.60666667"})).m_wallet_index_prices_sync)() == {
         "btcusdt": "79848.60666667"
     }
-    assert Client(session=FakeSession({"btc": "10.67520286"})).m_wallet_limits() == {"btc": "10.67520286"}
+    assert cast(Any, Client(session=FakeSession({"btc": "10.67520286"})).m_wallet_limits_sync)() == {
+        "btc": "10.67520286"
+    }
 
-    rates = Client(
-        session=FakeSession({"btc": {"hourly_interest_rate": "0.00000126", "next_hourly_interest_rate": "0.00000126"}})
-    ).m_wallet_interest_rates()
+    rates = cast(
+        Any,
+        Client(
+            session=FakeSession(
+                {"btc": {"hourly_interest_rate": "0.00000126", "next_hourly_interest_rate": "0.00000126"}}
+            )
+        ).m_wallet_interest_rates_sync,
+    )()
     assert rates == {"btc": InterestRate(hourly_interest_rate="0.00000126", next_hourly_interest_rate="0.00000126")}
 
 
@@ -242,7 +250,9 @@ def test_m_wallet_historical_index_prices_constructs_params_and_parses_prices() 
     session = FakeSession([{"timestamp": "1644572610000", "price": "43497.56666666"}])
     client = Client(base_url="https://example.test", session=session)
 
-    prices = client.m_wallet_historical_index_prices("btcusdt", start_time=1644572610000, end_time=1644572670000)
+    prices = cast(Any, client.m_wallet_historical_index_prices_sync)(
+        "btcusdt", start_time=1644572610000, end_time=1644572670000
+    )
 
     assert prices[0].timestamp == "1644572610000"
     assert prices[0].price == "43497.56666666"


### PR DESCRIPTION
## Summary
- migrate REST v3 Client to httpx.AsyncClient with async request and typed endpoint methods
- add async context-manager closing plus explicit *_sync convenience wrappers
- update docs, examples, unit tests, and live-test call sites for async-first usage

## Tests
- just

## Breaking change
Client REST methods now return coroutines and must be awaited. Use the explicit *_sync wrappers for synchronous scripts.