### PR TITLE
test(v3): use native async REST client tests

### DIFF
--- a/.agents/docs/TODO.md
+++ b/.agents/docs/TODO.md
@@ -11,7 +11,12 @@ Plan: [`plans/client-resilience-and-ergonomics-plan.md`](plans/client-resilience
 - [ ] Add WebSocket reconnect, heartbeat configuration, graceful cancellation, and non-blocking handler dispatch.
 - [ ] Add conservative REST retry/rate-limit support.
 - [ ] Add pagination helpers for historical/list endpoints.
-- [ ] Migrate REST `Client` to async-first methods with explicit `_sync` convenience wrappers.
+- [x] Migrate REST `Client` to async-first methods with explicit `_sync` convenience wrappers.
+- [ ] Harden `_sync` wrapper lifecycle after async-first migration; avoid or document cross-event-loop reuse of the underlying `httpx.AsyncClient`.
+- [ ] Replace generic `_sync` wrapper signatures with endpoint-specific parameters and return types for better IDE/type-checker support.
+- [x] Convert REST client tests toward native async style (`pytest.mark.anyio`) instead of relying mostly on `asyncio.run()` / `_sync` wrappers.
+- [ ] Add async pagination helpers / async iterators for historical and list endpoints, for example `async for order in client.iter_order_history(...)`.
+- [ ] Expand async lifecycle docs and examples, including `async with Client()`, `await client.aclose()`, `_sync` limitations in existing event loops, and a FastAPI dependency example.
 
 ## Dataclass Low-Level Models
 

--- a/tests/v3/conftest.py
+++ b/tests/v3/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Run AnyIO-marked REST client tests on asyncio only."""
+    return "asyncio"

--- a/tests/v3/test_client.py
+++ b/tests/v3/test_client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Mapping
 from typing import cast
 
@@ -9,6 +8,8 @@ import pytest
 from maicoin.v3.client import Client
 from maicoin.v3.errors import MaxAPIError
 from maicoin.v3.errors import MaxHTTPError
+
+pytestmark = pytest.mark.anyio
 
 
 class FakeResponse:
@@ -40,11 +41,11 @@ def last_kwargs(session: FakeSession) -> Mapping[str, object]:
     return cast("Mapping[str, object]", session.calls[-1]["kwargs"])
 
 
-def test_get_request_sends_params_as_query_params() -> None:
+async def test_get_request_sends_params_as_query_params() -> None:
     session = FakeSession(FakeResponse([{"id": "btctwd"}]))
     client = Client(base_url="https://example.test", session=session)
 
-    assert asyncio.run(client.request("GET", "/api/v3/markets", params={"foo": "bar"})) == [{"id": "btctwd"}]
+    assert await client.request("GET", "/api/v3/markets", params={"foo": "bar"}) == [{"id": "btctwd"}]
 
     assert session.calls[-1]["method"] == "GET"
     assert session.calls[-1]["url"] == "https://example.test/api/v3/markets"
@@ -52,11 +53,11 @@ def test_get_request_sends_params_as_query_params() -> None:
     assert "json" not in last_kwargs(session)
 
 
-def test_post_request_sends_params_as_json_body() -> None:
+async def test_post_request_sends_params_as_json_body() -> None:
     session = FakeSession(FakeResponse({"id": 1}))
     client = Client(base_url="https://example.test", session=session)
 
-    assert asyncio.run(client.request("POST", "api/v3/order", params={"market": "btctwd"})) == {"id": 1}
+    assert await client.request("POST", "api/v3/order", params={"market": "btctwd"}) == {"id": 1}
 
     assert session.calls[-1]["method"] == "POST"
     assert session.calls[-1]["url"] == "https://example.test/api/v3/order"
@@ -64,18 +65,18 @@ def test_post_request_sends_params_as_json_body() -> None:
     assert "params" not in last_kwargs(session)
 
 
-def test_delete_request_sends_params_as_json_body() -> None:
+async def test_delete_request_sends_params_as_json_body() -> None:
     session = FakeSession(FakeResponse({"ok": True}))
     client = Client(base_url="https://example.test", session=session)
 
-    assert asyncio.run(client.request("DELETE", "/api/v3/order", params={"id": 1})) == {"ok": True}
+    assert await client.request("DELETE", "/api/v3/order", params={"id": 1}) == {"ok": True}
 
     assert session.calls[-1]["method"] == "DELETE"
     assert last_kwargs(session)["json"] == {"id": 1}
     assert "params" not in last_kwargs(session)
 
 
-def test_authenticated_request_adds_max_headers() -> None:
+async def test_authenticated_request_adds_max_headers() -> None:
     session = FakeSession(FakeResponse({"ok": True}))
     client = Client(
         api_key="key",
@@ -85,7 +86,7 @@ def test_authenticated_request_adds_max_headers() -> None:
         nonce_factory=lambda: 123456,
     )
 
-    asyncio.run(client.request("GET", "/api/v3/wallet/spot/accounts", params={"currency": "btc"}, auth=True))
+    await client.request("GET", "/api/v3/wallet/spot/accounts", params={"currency": "btc"}, auth=True)
 
     headers = cast("Mapping[str, str]", last_kwargs(session)["headers"])
     assert headers["X-MAX-ACCESSKEY"] == "key"
@@ -97,28 +98,28 @@ def test_authenticated_request_adds_max_headers() -> None:
     assert last_kwargs(session)["params"] == {"nonce": 123456, "currency": "btc"}
 
 
-def test_http_error_response_raises() -> None:
+async def test_http_error_response_raises() -> None:
     client = Client(
         base_url="https://example.test",
         session=FakeSession(FakeResponse({"error": "invalid nonce"}, status_code=401)),
     )
 
     with pytest.raises(MaxHTTPError, match="invalid nonce"):
-        asyncio.run(client.request("GET", "/api/v3/wallet/spot/accounts"))
+        await client.request("GET", "/api/v3/wallet/spot/accounts")
 
 
-def test_api_error_payload_raises() -> None:
+async def test_api_error_payload_raises() -> None:
     client = Client(base_url="https://example.test", session=FakeSession(FakeResponse({"error": "bad request"})))
 
     with pytest.raises(MaxAPIError, match="bad request"):
-        asyncio.run(client.request("GET", "/api/v3/ticker"))
+        await client.request("GET", "/api/v3/ticker")
 
 
-def test_authenticated_request_requires_credentials() -> None:
+async def test_authenticated_request_requires_credentials() -> None:
     client = Client(base_url="https://example.test", session=FakeSession(FakeResponse({})))
 
     with pytest.raises(ValueError, match="api_key and api_secret"):
-        asyncio.run(client.request("GET", "/api/v3/wallet/spot/accounts", auth=True))
+        await client.request("GET", "/api/v3/wallet/spot/accounts", auth=True)
 
 
 def test_request_sync_wrapper_runs_async_request() -> None:
@@ -129,11 +130,10 @@ def test_request_sync_wrapper_runs_async_request() -> None:
     assert session.calls[-1]["url"] == "https://example.test/api/v3/ping"
 
 
-def test_async_context_manager_closes_session() -> None:
-    async def run() -> FakeSession:
-        session = FakeSession(FakeResponse({}))
-        async with Client(session=session):
-            assert not session.closed
-        return session
+async def test_async_context_manager_closes_session() -> None:
+    session = FakeSession(FakeResponse({}))
 
-    assert asyncio.run(run()).closed
+    async with Client(session=session):
+        assert not session.closed
+
+    assert session.closed

--- a/tests/v3/test_convert.py
+++ b/tests/v3/test_convert.py
@@ -5,8 +5,12 @@ import json
 from collections.abc import Mapping
 from typing import cast
 
+import pytest
+
 from maicoin.v3 import Client
 from maicoin.v3 import ConvertOrder
+
+pytestmark = pytest.mark.anyio
 
 
 class FakeResponse:
@@ -66,9 +70,9 @@ def convert_payload(**overrides: object) -> dict[str, object]:
     return payload
 
 
-def test_create_convert_constructs_authenticated_post_and_parses_payload() -> None:
+async def test_create_convert_constructs_authenticated_post_and_parses_payload() -> None:
     session = FakeSession(convert_payload())
-    convert = authenticated_client(session).create_convert_sync(
+    convert = await authenticated_client(session).create_convert(
         from_currency="btc",
         to_currency="usdt",
         from_amount="0.01",
@@ -86,9 +90,9 @@ def test_create_convert_constructs_authenticated_post_and_parses_payload() -> No
     assert last_payload(session)["path"] == "/api/v3/convert"
 
 
-def test_convert_detail_constructs_authenticated_get_and_parses_payload() -> None:
+async def test_convert_detail_constructs_authenticated_get_and_parses_payload() -> None:
     session = FakeSession(convert_payload())
-    convert = authenticated_client(session).convert_sync("6322d9bd-736b-4f19-b862-829e75cae1ce")
+    convert = await authenticated_client(session).convert("6322d9bd-736b-4f19-b862-829e75cae1ce")
 
     assert convert.sn == "6322d9bd-736b-4f19-b862-829e75cae1ce"
     assert session.calls[-1]["method"] == "GET"
@@ -96,9 +100,9 @@ def test_convert_detail_constructs_authenticated_get_and_parses_payload() -> Non
     assert last_kwargs(session)["params"] == {"nonce": 123456, "sn": "6322d9bd-736b-4f19-b862-829e75cae1ce"}
 
 
-def test_converts_constructs_authenticated_get_and_parses_list() -> None:
+async def test_converts_constructs_authenticated_get_and_parses_list() -> None:
     session = FakeSession([convert_payload()])
-    converts = authenticated_client(session).converts_sync(timestamp=1704937708, order="desc", limit=1)
+    converts = await authenticated_client(session).converts(timestamp=1704937708, order="desc", limit=1)
 
     assert converts == [ConvertOrder.model_validate(convert_payload())]
     assert session.calls[-1]["method"] == "GET"

--- a/tests/v3/test_funds.py
+++ b/tests/v3/test_funds.py
@@ -5,6 +5,8 @@ import json
 from collections.abc import Mapping
 from typing import cast
 
+import pytest
+
 from maicoin.v3 import Client
 from maicoin.v3 import Deposit
 from maicoin.v3 import DepositAddress
@@ -15,6 +17,8 @@ from maicoin.v3 import InternalTransfer
 from maicoin.v3 import Reward
 from maicoin.v3 import WithdrawAddress
 from maicoin.v3 import Withdrawal
+
+pytestmark = pytest.mark.anyio
 
 
 class FakeResponse:
@@ -145,16 +149,16 @@ def fund_transfer_payload(**overrides: object) -> dict[str, object]:
     return payload
 
 
-def test_withdrawal_methods_construct_authenticated_requests_and_parse_payloads() -> None:
+async def test_withdrawal_methods_construct_authenticated_requests_and_parse_payloads() -> None:
     detail_session = FakeSession(withdrawal_payload())
-    withdrawal = authenticated_client(detail_session).withdrawal_sync("18022603540001")
+    withdrawal = await authenticated_client(detail_session).withdrawal("18022603540001")
 
     assert withdrawal == Withdrawal.model_validate(withdrawal_payload())
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/withdrawal"
     assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "uuid": "18022603540001"}
 
     create_session = FakeSession(withdrawal_payload())
-    authenticated_client(create_session).create_withdrawal_sync(withdraw_address_uuid="addr-1", amount="0.019")
+    await authenticated_client(create_session).create_withdrawal(withdraw_address_uuid="addr-1", amount="0.019")
     assert create_session.calls[-1]["method"] == "POST"
     assert last_kwargs(create_session)["json"] == {
         "nonce": 123456,
@@ -164,14 +168,14 @@ def test_withdrawal_methods_construct_authenticated_requests_and_parse_payloads(
     assert last_payload(create_session)["path"] == "/api/v3/withdrawal"
 
     twd_session = FakeSession(withdrawal_payload(currency="twd", network_protocol=None, amount="100"))
-    authenticated_client(twd_session).create_twd_withdrawal_sync("100")
+    await authenticated_client(twd_session).create_twd_withdrawal("100")
     assert twd_session.calls[-1]["url"] == "https://example.test/api/v3/withdrawal/twd"
     assert last_kwargs(twd_session)["json"] == {"nonce": 123456, "amount": "100"}
 
 
-def test_withdrawals_and_withdraw_addresses_parse_lists() -> None:
+async def test_withdrawals_and_withdraw_addresses_parse_lists() -> None:
     withdrawals_session = FakeSession([withdrawal_payload()])
-    withdrawals = authenticated_client(withdrawals_session).withdrawals_sync(currency="usdt", state="done", limit=1)
+    withdrawals = await authenticated_client(withdrawals_session).withdrawals(currency="usdt", state="done", limit=1)
 
     assert withdrawals == [Withdrawal.model_validate(withdrawal_payload())]
     assert withdrawals_session.calls[-1]["url"] == "https://example.test/api/v3/withdrawals"
@@ -194,23 +198,23 @@ def test_withdrawals_and_withdraw_addresses_parse_lists() -> None:
         "network_congested": False,
     }
     address_session = FakeSession([address_payload])
-    addresses = authenticated_client(address_session).withdraw_addresses_sync("usdt", limit=10, offset=20)
+    addresses = await authenticated_client(address_session).withdraw_addresses("usdt", limit=10, offset=20)
 
     assert addresses == [WithdrawAddress.model_validate(address_payload)]
     assert address_session.calls[-1]["url"] == "https://example.test/api/v3/withdraw_addresses"
     assert last_kwargs(address_session)["params"] == {"nonce": 123456, "currency": "usdt", "limit": 10, "offset": 20}
 
 
-def test_deposit_methods_construct_authenticated_requests_and_parse_payloads() -> None:
+async def test_deposit_methods_construct_authenticated_requests_and_parse_payloads() -> None:
     detail_session = FakeSession(deposit_payload())
-    deposit = authenticated_client(detail_session).deposit_sync(uuid="18022603540001")
+    deposit = await authenticated_client(detail_session).deposit(uuid="18022603540001")
 
     assert deposit == Deposit.model_validate(deposit_payload())
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/deposit"
     assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "uuid": "18022603540001"}
 
     deposits_session = FakeSession([deposit_payload()])
-    deposits = authenticated_client(deposits_session).deposits_sync(currency="usdt", order="asc", limit=1)
+    deposits = await authenticated_client(deposits_session).deposits(currency="usdt", order="asc", limit=1)
     assert deposits == [Deposit.model_validate(deposit_payload())]
     assert last_kwargs(deposits_session)["params"] == {"nonce": 123456, "currency": "usdt", "order": "asc", "limit": 1}
 
@@ -221,13 +225,13 @@ def test_deposit_methods_construct_authenticated_requests_and_parse_payloads() -
         "address": "TU91BoeyrqW9MKaiRPDiE6z7UecK2n2Hze",
     }
     address_session = FakeSession(address_payload)
-    address = authenticated_client(address_session).deposit_address_sync("trc20usdt")
+    address = await authenticated_client(address_session).deposit_address("trc20usdt")
     assert address == DepositAddress.model_validate(address_payload)
     assert address_session.calls[-1]["url"] == "https://example.test/api/v3/deposit_address"
     assert last_kwargs(address_session)["params"] == {"nonce": 123456, "currency_version": "trc20usdt"}
 
 
-def test_internal_transfers_and_rewards_construct_requests_and_parse_payloads() -> None:
+async def test_internal_transfers_and_rewards_construct_requests_and_parse_payloads() -> None:
     transfer_payload = {
         "uuid": "18032011380001",
         "currency": "eth",
@@ -238,7 +242,7 @@ def test_internal_transfers_and_rewards_construct_requests_and_parse_payloads() 
         "state": "done",
     }
     transfer_session = FakeSession([transfer_payload])
-    transfers = authenticated_client(transfer_session).internal_transfers_sync("in", currency="eth", limit=1)
+    transfers = await authenticated_client(transfer_session).internal_transfers("in", currency="eth", limit=1)
 
     assert transfers == [InternalTransfer.model_validate(transfer_payload)]
     assert transfers[0].from_ == "pr***@***.com"
@@ -253,16 +257,16 @@ def test_internal_transfers_and_rewards_construct_requests_and_parse_payloads() 
         "note": "2018-11-13 Holding Reward",
     }
     reward_session = FakeSession([reward_payload])
-    rewards = authenticated_client(reward_session).rewards_sync(reward_type="airdrop_reward", limit=1)
+    rewards = await authenticated_client(reward_session).rewards(reward_type="airdrop_reward", limit=1)
 
     assert rewards == [Reward.model_validate(reward_payload)]
     assert reward_session.calls[-1]["url"] == "https://example.test/api/v3/rewards"
     assert last_kwargs(reward_session)["params"] == {"nonce": 123456, "reward_type": "airdrop_reward", "limit": 1}
 
 
-def test_fund_transaction_deposit_methods_parse_list_and_detail() -> None:
+async def test_fund_transaction_deposit_methods_parse_list_and_detail() -> None:
     list_session = FakeSession([fund_deposit_payload()])
-    deposits = authenticated_client(list_session).fund_transaction_deposits_sync(
+    deposits = await authenticated_client(list_session).fund_transaction_deposits(
         timestamp=1521726960123, order="desc", limit=1
     )
 
@@ -277,29 +281,30 @@ def test_fund_transaction_deposit_methods_parse_list_and_detail() -> None:
     }
 
     detail_session = FakeSession(fund_deposit_payload())
-    assert authenticated_client(detail_session).fund_transaction_deposit_sync("18022603540001").sn == "18022603540001"
+    detail = await authenticated_client(detail_session).fund_transaction_deposit("18022603540001")
+    assert detail.sn == "18022603540001"
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/deposit"
     assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "sn": "18022603540001"}
 
 
-def test_fund_transaction_withdrawal_methods_parse_list_and_detail() -> None:
+async def test_fund_transaction_withdrawal_methods_parse_list_and_detail() -> None:
     list_session = FakeSession([fund_withdrawal_payload()])
-    withdrawals = authenticated_client(list_session).fund_transaction_withdrawals_sync(limit=1)
+    withdrawals = await authenticated_client(list_session).fund_transaction_withdrawals(limit=1)
 
     assert withdrawals == [FundTransactionWithdrawal.model_validate(fund_withdrawal_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/withdrawals"
     assert last_kwargs(list_session)["params"] == {"nonce": 123456, "limit": 1}
 
     detail_session = FakeSession(fund_withdrawal_payload())
-    withdrawal = authenticated_client(detail_session).fund_transaction_withdrawal_sync("18022603540001")
+    withdrawal = await authenticated_client(detail_session).fund_transaction_withdrawal("18022603540001")
     assert withdrawal.sn == "18022603540001"
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/withdrawal"
     assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "sn": "18022603540001"}
 
 
-def test_fund_transaction_transfer_methods_parse_list_and_detail() -> None:
+async def test_fund_transaction_transfer_methods_parse_list_and_detail() -> None:
     list_session = FakeSession([fund_transfer_payload()])
-    transfers = authenticated_client(list_session).fund_transaction_transfers_sync(limit=1)
+    transfers = await authenticated_client(list_session).fund_transaction_transfers(limit=1)
 
     assert transfers == [FundTransactionTransfer.model_validate(fund_transfer_payload())]
     assert transfers[0].from_.wallet_type == "spot"
@@ -307,6 +312,7 @@ def test_fund_transaction_transfer_methods_parse_list_and_detail() -> None:
     assert last_kwargs(list_session)["params"] == {"nonce": 123456, "limit": 1}
 
     detail_session = FakeSession(fund_transfer_payload())
-    assert authenticated_client(detail_session).fund_transaction_transfer_sync("18022603540001").sn == "18022603540001"
+    detail = await authenticated_client(detail_session).fund_transaction_transfer("18022603540001")
+    assert detail.sn == "18022603540001"
     assert detail_session.calls[-1]["url"] == "https://example.test/api/v3/fund_transactions/transfer"
     assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "sn": "18022603540001"}

--- a/tests/v3/test_m_wallet_private.py
+++ b/tests/v3/test_m_wallet_private.py
@@ -5,6 +5,8 @@ import json
 from collections.abc import Mapping
 from typing import cast
 
+import pytest
+
 from maicoin.v3 import Client
 from maicoin.v3 import MWalletADRatio
 from maicoin.v3 import MWalletInterest
@@ -13,6 +15,8 @@ from maicoin.v3 import MWalletLiquidationDetail
 from maicoin.v3 import MWalletLoan
 from maicoin.v3 import MWalletRepayment
 from maicoin.v3 import MWalletTransfer
+
+pytestmark = pytest.mark.anyio
 
 
 class FakeResponse:
@@ -132,9 +136,9 @@ def liquidation_detail_payload() -> dict[str, object]:
     )
 
 
-def test_create_m_wallet_loan_and_history_construct_authenticated_requests() -> None:
+async def test_create_m_wallet_loan_and_history_construct_authenticated_requests() -> None:
     create_session = FakeSession(loan_payload())
-    loan = authenticated_client(create_session).create_m_wallet_loan_sync(currency="eth", amount="0.019")
+    loan = await authenticated_client(create_session).create_m_wallet_loan(currency="eth", amount="0.019")
 
     assert loan == MWalletLoan.model_validate(loan_payload())
     assert create_session.calls[-1]["method"] == "POST"
@@ -143,7 +147,7 @@ def test_create_m_wallet_loan_and_history_construct_authenticated_requests() -> 
     assert last_payload(create_session)["path"] == "/api/v3/wallet/m/loan"
 
     list_session = FakeSession([loan_payload()])
-    loans = authenticated_client(list_session).m_wallet_loans_sync(
+    loans = await authenticated_client(list_session).m_wallet_loans(
         "eth", timestamp=1521726960357, order="desc", limit=1
     )
     assert loans == [MWalletLoan.model_validate(loan_payload())]
@@ -157,9 +161,9 @@ def test_create_m_wallet_loan_and_history_construct_authenticated_requests() -> 
     }
 
 
-def test_m_wallet_transfer_create_and_history_construct_requests() -> None:
+async def test_m_wallet_transfer_create_and_history_construct_requests() -> None:
     create_session = FakeSession(transfer_payload())
-    transfer = authenticated_client(create_session).create_m_wallet_transfer_sync(
+    transfer = await authenticated_client(create_session).create_m_wallet_transfer(
         currency="eth", amount="0.019", side="in"
     )
 
@@ -169,15 +173,15 @@ def test_m_wallet_transfer_create_and_history_construct_requests() -> None:
     assert last_kwargs(create_session)["json"] == {"nonce": 123456, "currency": "eth", "amount": "0.019", "side": "in"}
 
     list_session = FakeSession([transfer_payload()])
-    transfers = authenticated_client(list_session).m_wallet_transfers_sync(currency="eth", side="in", limit=1)
+    transfers = await authenticated_client(list_session).m_wallet_transfers(currency="eth", side="in", limit=1)
     assert transfers == [MWalletTransfer.model_validate(transfer_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/transfers"
     assert last_kwargs(list_session)["params"] == {"nonce": 123456, "currency": "eth", "side": "in", "limit": 1}
 
 
-def test_m_wallet_repayment_create_and_history_construct_requests() -> None:
+async def test_m_wallet_repayment_create_and_history_construct_requests() -> None:
     create_session = FakeSession(repayment_payload())
-    repayment = authenticated_client(create_session).create_m_wallet_repayment_sync(currency="eth", amount="0.15")
+    repayment = await authenticated_client(create_session).create_m_wallet_repayment(currency="eth", amount="0.15")
 
     assert repayment == MWalletRepayment.model_validate(repayment_payload())
     assert create_session.calls[-1]["method"] == "POST"
@@ -185,22 +189,22 @@ def test_m_wallet_repayment_create_and_history_construct_requests() -> None:
     assert last_kwargs(create_session)["json"] == {"nonce": 123456, "currency": "eth", "amount": "0.15"}
 
     list_session = FakeSession([repayment_payload()])
-    repayments = authenticated_client(list_session).m_wallet_repayments_sync("eth", order="asc", limit=1)
+    repayments = await authenticated_client(list_session).m_wallet_repayments("eth", order="asc", limit=1)
     assert repayments == [MWalletRepayment.model_validate(repayment_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/repayments"
     assert last_kwargs(list_session)["params"] == {"nonce": 123456, "currency": "eth", "order": "asc", "limit": 1}
 
 
-def test_m_wallet_liquidations_and_detail_parse_nested_payloads() -> None:
+async def test_m_wallet_liquidations_and_detail_parse_nested_payloads() -> None:
     list_session = FakeSession([liquidation_payload()])
-    liquidations = authenticated_client(list_session).m_wallet_liquidations_sync(limit=1)
+    liquidations = await authenticated_client(list_session).m_wallet_liquidations(limit=1)
 
     assert liquidations == [MWalletLiquidation.model_validate(liquidation_payload())]
     assert list_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/liquidations"
     assert last_kwargs(list_session)["params"] == {"nonce": 123456, "limit": 1}
 
     detail_session = FakeSession(liquidation_detail_payload())
-    detail = authenticated_client(detail_session).m_wallet_liquidation_sync("210407080800050666")
+    detail = await authenticated_client(detail_session).m_wallet_liquidation("210407080800050666")
     assert detail == MWalletLiquidationDetail.model_validate(liquidation_detail_payload())
     assert detail.repayments[0].principal == "0.1"
     assert detail.liquidations[0].repayment.interest == "0.05"
@@ -208,7 +212,7 @@ def test_m_wallet_liquidations_and_detail_parse_nested_payloads() -> None:
     assert last_kwargs(detail_session)["params"] == {"nonce": 123456, "sn": "210407080800050666"}
 
 
-def test_m_wallet_interests_and_ad_ratio_construct_authenticated_requests() -> None:
+async def test_m_wallet_interests_and_ad_ratio_construct_authenticated_requests() -> None:
     interest_payload = {
         "currency": "eth",
         "amount": "0.003",
@@ -217,7 +221,7 @@ def test_m_wallet_interests_and_ad_ratio_construct_authenticated_requests() -> N
         "created_at": 1521726960123,
     }
     interests_session = FakeSession([interest_payload])
-    interests = authenticated_client(interests_session).m_wallet_interests_sync(currency="eth", limit=1)
+    interests = await authenticated_client(interests_session).m_wallet_interests(currency="eth", limit=1)
 
     assert interests == [MWalletInterest.model_validate(interest_payload)]
     assert interests_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/interests"
@@ -225,7 +229,7 @@ def test_m_wallet_interests_and_ad_ratio_construct_authenticated_requests() -> N
 
     ad_ratio_payload = {"ad_ratio": "1.21", "asset_in_usdt": "2639.98128484", "debt_in_usdt": "2165.54482641"}
     ad_ratio_session = FakeSession(ad_ratio_payload)
-    ad_ratio = authenticated_client(ad_ratio_session).m_wallet_ad_ratio_sync()
+    ad_ratio = await authenticated_client(ad_ratio_session).m_wallet_ad_ratio()
     assert ad_ratio == MWalletADRatio.model_validate(ad_ratio_payload)
     assert ad_ratio_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/ad_ratio"
     assert last_payload(ad_ratio_session) == {"nonce": 123456, "path": "/api/v3/wallet/m/ad_ratio"}

--- a/tests/v3/test_private.py
+++ b/tests/v3/test_private.py
@@ -5,6 +5,8 @@ import json
 from collections.abc import Mapping
 from typing import cast
 
+import pytest
+
 from maicoin.v3 import Account
 from maicoin.v3 import Client
 from maicoin.v3 import Order
@@ -13,6 +15,8 @@ from maicoin.v3 import OrderState
 from maicoin.v3 import OrderType
 from maicoin.v3 import PrivateTrade
 from maicoin.v3 import UserInfo
+
+pytestmark = pytest.mark.anyio
 
 
 class FakeResponse:
@@ -80,7 +84,7 @@ def order_payload(**overrides: object) -> dict[str, object]:
     return payload
 
 
-def test_info_constructs_authenticated_request_and_parses_user_info() -> None:
+async def test_info_constructs_authenticated_request_and_parses_user_info() -> None:
     payload = {
         "email": "max@maicoin.com",
         "level": 0,
@@ -95,7 +99,7 @@ def test_info_constructs_authenticated_request_and_parses_user_info() -> None:
         "next_vip_level": None,
     }
     session = FakeSession(payload)
-    info = authenticated_client(session).info_sync()
+    info = await authenticated_client(session).info()
 
     assert info == UserInfo.model_validate(payload)
     assert session.calls[-1]["method"] == "GET"
@@ -103,11 +107,11 @@ def test_info_constructs_authenticated_request_and_parses_user_info() -> None:
     assert last_payload(session) == {"nonce": 123456, "path": "/api/v3/info"}
 
 
-def test_accounts_constructs_authenticated_request_and_parses_accounts() -> None:
+async def test_accounts_constructs_authenticated_request_and_parses_accounts() -> None:
     session = FakeSession([{"currency": "twd", "balance": "100000.0", "locked": "5566.0", "staked": None}])
     client = authenticated_client(session)
 
-    accounts = client.accounts_sync(currency="twd")
+    accounts = await client.accounts(currency="twd")
 
     assert accounts == [Account(currency="twd", balance="100000.0", locked="5566.0", staked=None)]
     assert session.calls[-1]["method"] == "GET"
@@ -120,25 +124,26 @@ def test_accounts_constructs_authenticated_request_and_parses_accounts() -> None
     }
 
 
-def test_open_closed_and_history_orders_parse_order_models() -> None:
+async def test_open_closed_and_history_orders_parse_order_models() -> None:
     expected_order = Order.model_validate(order_payload())
 
     open_session = FakeSession([order_payload()])
-    assert authenticated_client(open_session).open_orders_sync(market="ethtwd", limit=1) == [expected_order]
+    assert await authenticated_client(open_session).open_orders(market="ethtwd", limit=1) == [expected_order]
     assert open_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/orders/open"
     assert last_kwargs(open_session)["params"] == {"nonce": 123456, "market": "ethtwd", "limit": 1}
 
     closed_session = FakeSession([order_payload(state="done")])
-    assert authenticated_client(closed_session).closed_orders_sync(wallet_type="m")[0].state == "done"
+    closed_orders = await authenticated_client(closed_session).closed_orders(wallet_type="m")
+    assert closed_orders[0].state == "done"
     assert closed_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/orders/closed"
 
     history_session = FakeSession([order_payload()])
-    history = authenticated_client(history_session).order_history_sync("ethtwd", from_id=10, limit=50)
+    history = await authenticated_client(history_session).order_history("ethtwd", from_id=10, limit=50)
     assert history == [expected_order]
     assert last_kwargs(history_session)["params"] == {"nonce": 123456, "market": "ethtwd", "from_id": 10, "limit": 50}
 
 
-def test_wallet_trades_constructs_authenticated_request_and_parses_private_trades() -> None:
+async def test_wallet_trades_constructs_authenticated_request_and_parses_private_trades() -> None:
     trade_payload = {
         "id": 68444,
         "order_id": 87,
@@ -156,7 +161,7 @@ def test_wallet_trades_constructs_authenticated_request_and_parses_private_trade
         "created_at": 1521726960357,
     }
     session = FakeSession([trade_payload])
-    trades = authenticated_client(session).wallet_trades_sync(market="ethtwd", from_id=68444, order="asc", limit=1)
+    trades = await authenticated_client(session).wallet_trades(market="ethtwd", from_id=68444, order="asc", limit=1)
 
     assert trades == [PrivateTrade.model_validate(trade_payload)]
     assert session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/trades"
@@ -170,9 +175,9 @@ def test_wallet_trades_constructs_authenticated_request_and_parses_private_trade
     assert last_payload(session)["path"] == "/api/v3/wallet/spot/trades"
 
 
-def test_order_lookup_and_order_trades_construct_requests() -> None:
+async def test_order_lookup_and_order_trades_construct_requests() -> None:
     order_session = FakeSession(order_payload())
-    order = authenticated_client(order_session).order_sync(order_id=87)
+    order = await authenticated_client(order_session).order(order_id=87)
 
     assert order.id == 87
     assert order.side is OrderSide.BUY
@@ -198,16 +203,16 @@ def test_order_lookup_and_order_trades_construct_requests() -> None:
         "created_at": 1521726960357,
     }
     trade_session = FakeSession([trade_payload])
-    trades = authenticated_client(trade_session).order_trades_sync(client_oid="client-1")
+    trades = await authenticated_client(trade_session).order_trades(client_oid="client-1")
 
     assert trades == [PrivateTrade.model_validate(trade_payload)]
     assert trade_session.calls[-1]["url"] == "https://example.test/api/v3/order/trades"
     assert last_kwargs(trade_session)["params"] == {"nonce": 123456, "client_oid": "client-1"}
 
 
-def test_create_and_cancel_order_send_authenticated_json_body() -> None:
+async def test_create_and_cancel_order_send_authenticated_json_body() -> None:
     create_session = FakeSession(order_payload())
-    created = authenticated_client(create_session).create_order_sync(
+    created = await authenticated_client(create_session).create_order(
         "ethtwd",
         OrderSide.BUY,
         "0.2658",
@@ -231,13 +236,14 @@ def test_create_and_cancel_order_send_authenticated_json_body() -> None:
     assert last_payload(create_session)["path"] == "/api/v3/wallet/spot/order"
 
     cancel_session = FakeSession(order_payload(state="cancel"))
-    assert authenticated_client(cancel_session).cancel_order_sync(order_id=87).state == "cancel"
+    cancelled_order = await authenticated_client(cancel_session).cancel_order(order_id=87)
+    assert cancelled_order.state == "cancel"
     assert cancel_session.calls[-1]["method"] == "DELETE"
     assert cancel_session.calls[-1]["url"] == "https://example.test/api/v3/order"
     assert last_kwargs(cancel_session)["json"] == {"nonce": 123456, "id": 87}
 
     cancel_all_session = FakeSession([order_payload(state="cancel")])
-    cancelled = authenticated_client(cancel_all_session).cancel_orders_sync(market="ethtwd", side="buy")
+    cancelled = await authenticated_client(cancel_all_session).cancel_orders(market="ethtwd", side="buy")
     assert cancelled[0].state == "cancel"
     assert cancel_all_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/orders"
     assert last_kwargs(cancel_all_session)["json"] == {"nonce": 123456, "market": "ethtwd", "side": "buy"}

--- a/tests/v3/test_public.py
+++ b/tests/v3/test_public.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
 from typing import cast
+
+import pytest
 
 from maicoin.v3 import Client
 from maicoin.v3 import Depth
@@ -10,6 +11,8 @@ from maicoin.v3 import InterestRate
 from maicoin.v3 import KLine
 from maicoin.v3 import Market
 from maicoin.v3 import Ticker
+
+pytestmark = pytest.mark.anyio
 
 
 class FakeResponse:
@@ -38,7 +41,7 @@ def last_params(session: FakeSession) -> Mapping[str, object]:
     return cast("Mapping[str, object]", kwargs["params"])
 
 
-def test_markets_returns_market_models() -> None:
+async def test_markets_returns_market_models() -> None:
     session = FakeSession(
         [
             {
@@ -56,7 +59,7 @@ def test_markets_returns_market_models() -> None:
     )
     client = Client(base_url="https://example.test", session=session)
 
-    markets = cast(Any, client.markets_sync)()
+    markets = await client.markets()
 
     assert markets == [
         Market(
@@ -74,7 +77,7 @@ def test_markets_returns_market_models() -> None:
     assert session.calls[-1]["url"] == "https://example.test/api/v3/markets"
 
 
-def test_currencies_returns_currency_models() -> None:
+async def test_currencies_returns_currency_models() -> None:
     session = FakeSession(
         [
             {
@@ -106,30 +109,30 @@ def test_currencies_returns_currency_models() -> None:
     )
     client = Client(base_url="https://example.test", session=session)
 
-    currencies = cast(Any, client.currencies_sync)()
+    currencies = await client.currencies()
 
     assert currencies[0].currency == "usdt"
     assert currencies[0].networks[0].id == "trc20usdt"
     assert currencies[0].staking is None
 
 
-def test_timestamp_returns_timestamp_model() -> None:
+async def test_timestamp_returns_timestamp_model() -> None:
     client = Client(base_url="https://example.test", session=FakeSession({"timestamp": 1678766175}))
 
-    assert cast(Any, client.timestamp_sync)().timestamp == 1678766175
+    assert (await client.timestamp()).timestamp == 1678766175
 
 
-def test_kline_constructs_params_and_parses_rows() -> None:
+async def test_kline_constructs_params_and_parses_rows() -> None:
     session = FakeSession([[1678766100, "1", "2", "0.5", "1.5", "42"]])
     client = Client(base_url="https://example.test", session=session)
 
-    klines = cast(Any, client.kline_sync)("btctwd", limit=1, period=5, timestamp=1678766100)
+    klines = await client.kline("btctwd", limit=1, period=5, timestamp=1678766100)
 
     assert klines == [KLine(timestamp=1678766100, open="1", high="2", low="0.5", close="1.5", volume="42")]
     assert last_params(session) == {"market": "btctwd", "limit": 1, "period": 5, "timestamp": 1678766100}
 
 
-def test_depth_constructs_params_and_parses_depth() -> None:
+async def test_depth_constructs_params_and_parses_depth() -> None:
     session = FakeSession(
         {
             "timestamp": 1778249163,
@@ -141,7 +144,7 @@ def test_depth_constructs_params_and_parses_depth() -> None:
     )
     client = Client(base_url="https://example.test", session=session)
 
-    depth = cast(Any, client.depth_sync)("btctwd", limit=1, sort_by_price=True)
+    depth = await client.depth("btctwd", limit=1, sort_by_price=True)
 
     assert depth == Depth(
         timestamp=1778249163,
@@ -153,7 +156,7 @@ def test_depth_constructs_params_and_parses_depth() -> None:
     assert last_params(session) == {"market": "btctwd", "limit": 1, "sort_by_price": True}
 
 
-def test_trades_constructs_params_and_parses_trades() -> None:
+async def test_trades_constructs_params_and_parses_trades() -> None:
     session = FakeSession(
         [
             {
@@ -169,14 +172,14 @@ def test_trades_constructs_params_and_parses_trades() -> None:
     )
     client = Client(base_url="https://example.test", session=session)
 
-    trades = cast(Any, client.trades_sync)("ethtwd", timestamp=1521726960357, limit=1)
+    trades = await client.trades("ethtwd", timestamp=1521726960357, limit=1)
 
     assert trades[0].id == 68444
     assert trades[0].side == "bid"
     assert last_params(session) == {"market": "ethtwd", "timestamp": 1521726960357, "limit": 1}
 
 
-def test_tickers_uses_bracket_array_param_and_parses_tickers() -> None:
+async def test_tickers_uses_bracket_array_param_and_parses_tickers() -> None:
     ticker_payload = {
         "market": "btctwd",
         "at": 1531905257,
@@ -195,13 +198,13 @@ def test_tickers_uses_bracket_array_param_and_parses_tickers() -> None:
     session = FakeSession([ticker_payload])
     client = Client(base_url="https://example.test", session=session)
 
-    tickers = cast(Any, client.tickers_sync)(["btctwd", "ethusdt"])
+    tickers = await client.tickers(["btctwd", "ethusdt"])
 
     assert tickers == [Ticker.model_validate(ticker_payload)]
     assert last_params(session) == {"markets[]": ["btctwd", "ethusdt"]}
 
 
-def test_ticker_constructs_params_and_parses_ticker() -> None:
+async def test_ticker_constructs_params_and_parses_ticker() -> None:
     session = FakeSession(
         {
             "market": "btctwd",
@@ -221,38 +224,29 @@ def test_ticker_constructs_params_and_parses_ticker() -> None:
     )
     client = Client(base_url="https://example.test", session=session)
 
-    ticker = cast(Any, client.ticker_sync)("btctwd")
+    ticker = await client.ticker("btctwd")
 
     assert ticker.market == "btctwd"
     assert last_params(session) == {"market": "btctwd"}
 
 
-def test_m_wallet_public_methods_parse_payloads() -> None:
-    assert cast(Any, Client(session=FakeSession({"btcusdt": "79848.60666667"})).m_wallet_index_prices_sync)() == {
+async def test_m_wallet_public_methods_parse_payloads() -> None:
+    assert await Client(session=FakeSession({"btcusdt": "79848.60666667"})).m_wallet_index_prices() == {
         "btcusdt": "79848.60666667"
     }
-    assert cast(Any, Client(session=FakeSession({"btc": "10.67520286"})).m_wallet_limits_sync)() == {
-        "btc": "10.67520286"
-    }
+    assert await Client(session=FakeSession({"btc": "10.67520286"})).m_wallet_limits() == {"btc": "10.67520286"}
 
-    rates = cast(
-        Any,
-        Client(
-            session=FakeSession(
-                {"btc": {"hourly_interest_rate": "0.00000126", "next_hourly_interest_rate": "0.00000126"}}
-            )
-        ).m_wallet_interest_rates_sync,
-    )()
+    rates = await Client(
+        session=FakeSession({"btc": {"hourly_interest_rate": "0.00000126", "next_hourly_interest_rate": "0.00000126"}})
+    ).m_wallet_interest_rates()
     assert rates == {"btc": InterestRate(hourly_interest_rate="0.00000126", next_hourly_interest_rate="0.00000126")}
 
 
-def test_m_wallet_historical_index_prices_constructs_params_and_parses_prices() -> None:
+async def test_m_wallet_historical_index_prices_constructs_params_and_parses_prices() -> None:
     session = FakeSession([{"timestamp": "1644572610000", "price": "43497.56666666"}])
     client = Client(base_url="https://example.test", session=session)
 
-    prices = cast(Any, client.m_wallet_historical_index_prices_sync)(
-        "btcusdt", start_time=1644572610000, end_time=1644572670000
-    )
+    prices = await client.m_wallet_historical_index_prices("btcusdt", start_time=1644572610000, end_time=1644572670000)
 
     assert prices[0].timestamp == "1644572610000"
     assert prices[0].price == "43497.56666666"


### PR DESCRIPTION
## Summary
- convert REST v3 client tests to pytest.mark.anyio native async tests
- add an AnyIO asyncio backend fixture for REST client tests
- keep focused coverage for the explicit request_sync() wrapper
- update async TODO status

## Tests
- just