### PR TITLE
docs: archive dataclass low-level models plan

### DIFF
--- a/.agents/docs/TODO.md
+++ b/.agents/docs/TODO.md
@@ -18,12 +18,6 @@ Plan: [`plans/client-resilience-and-ergonomics-plan.md`](plans/client-resilience
 - [ ] Add async pagination helpers / async iterators for historical and list endpoints, for example `async for order in client.iter_order_history(...)`.
 - [ ] Expand async lifecycle docs and examples, including `async with Client()`, `await client.aclose()`, `_sync` limitations in existing event loops, and a FastAPI dependency example.
 
-## Dataclass Low-Level Models
-
-Plan: [`plans/dataclass-low-level-models-plan.md`](plans/dataclass-low-level-models-plan.md)
-
-- [ ] Re-evaluate a dataclass data layer with benchmarks before implementation while keeping Pydantic as the high-level validated API.
-
 ## Completed Milestones
 
 - REST v3 foundation, public endpoints, private order/trade/account endpoints, wallet funds, convert, and M-Wallet private endpoints.

--- a/.agents/docs/archived/dataclass-low-level-models-plan.md
+++ b/.agents/docs/archived/dataclass-low-level-models-plan.md
@@ -1,3 +1,23 @@
+# Archived: Dataclass Low-Level Models Plan
+
+**Status:** Rejected after benchmarking. Do not re-open without new evidence.
+
+This plan proposed introducing a fast `@dataclass`-based low-level layer
+alongside the existing Pydantic models. The experiment was implemented and
+benchmarked, and the result was that `@dataclass(slots=True, frozen=True)`
+parsing and instantiation was **slower than `pydantic.BaseModel`** for the
+REST v3 and WebSocket payload shapes used by this package. The change was
+reverted to keep Pydantic as the only model layer.
+
+Relevant commits:
+
+- `0e3cb72 refactor(ws): use dataclasses for response payloads` — the experiment.
+- `f4b9548 Revert "refactor: use dataclasses"` — the rollback after benchmarking.
+
+The original plan body is preserved below as historical context only.
+
+---
+
 # Low-Level Dataclass Models Plan
 
 ## Goal


### PR DESCRIPTION
## Summary
- move the dataclass low-level models plan into archived docs
- record the benchmark-based rejection rationale and related commits
- remove the stale TODO entry for re-evaluating the dataclass layer

## Tests
- not run; docs-only change