### PR TITLE
fix(v3): refresh default sessions for sync wrappers

### DIFF
--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -125,8 +125,20 @@ class Client:
         self.api_secret = api_secret
         self.base_url = base_url
         self.timeout = timeout
-        self.session: RequestSession = cast("RequestSession", httpx.AsyncClient()) if session is None else session
+        self._owns_session = session is None
+        self._session: RequestSession | None = session
         self.nonce_factory = nonce_factory
+
+    @property
+    def session(self) -> RequestSession:
+        """Underlying async HTTP session, created lazily for default clients."""
+        if self._session is None:
+            self._session = cast("RequestSession", httpx.AsyncClient())
+        return self._session
+
+    @session.setter
+    def session(self, session: RequestSession) -> None:
+        self._session = session
 
     async def __aenter__(self) -> Client:
         return self
@@ -136,14 +148,28 @@ class Client:
 
     async def aclose(self) -> None:
         """Close the underlying async HTTP session when it supports closing."""
-        aclose = getattr(self.session, "aclose", None)
+        if self._session is None:
+            return
+        aclose = getattr(self._session, "aclose", None)
         if aclose is not None:
             await aclose()
+        if self._owns_session:
+            self._session = None
 
     def _run_sync(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
         """Run one async REST method for synchronous scripts."""
         method = getattr(self, method_name)
-        return asyncio.run(method(*args, **kwargs))
+        if not self._owns_session:
+            return asyncio.run(method(*args, **kwargs))
+
+        async def runner() -> Any:
+            self._session = cast("RequestSession", httpx.AsyncClient())
+            try:
+                return await method(*args, **kwargs)
+            finally:
+                await self.aclose()
+
+        return asyncio.run(runner())
 
     def request_sync(self, *args: Any, **kwargs: Any) -> Any:
         """Synchronous convenience wrapper."""

--- a/tests/v3/test_client.py
+++ b/tests/v3/test_client.py
@@ -130,6 +130,24 @@ def test_request_sync_wrapper_runs_async_request() -> None:
     assert session.calls[-1]["url"] == "https://example.test/api/v3/ping"
 
 
+def test_default_sync_wrappers_use_fresh_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
+    sessions: list[FakeSession] = []
+
+    def session_factory() -> FakeSession:
+        session = FakeSession(FakeResponse({"timestamp": 1678766175}))
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr("maicoin.v3.client.httpx.AsyncClient", session_factory)
+    client = Client(base_url="https://example.test")
+
+    assert client.timestamp_sync().timestamp == 1678766175
+    assert client.timestamp_sync().timestamp == 1678766175
+
+    assert len(sessions) == 2
+    assert all(session.closed for session in sessions)
+
+
 async def test_async_context_manager_closes_session() -> None:
     session = FakeSession(FakeResponse({}))
 


### PR DESCRIPTION
## Summary
- Lazily create the default async HTTP session for v3 clients
- Use a fresh owned httpx.AsyncClient for each sync wrapper call to avoid reusing transports across closed event loops
- Add a regression test for repeated sync wrapper calls

## Test results
- just live-test
- just