### PR TITLE
fix(v3): guard sync wrappers in event loops

### DIFF
--- a/.agents/docs/TODO.md
+++ b/.agents/docs/TODO.md
@@ -12,11 +12,11 @@ Plan: [`plans/client-resilience-and-ergonomics-plan.md`](plans/client-resilience
 - [ ] Add conservative REST retry/rate-limit support.
 - [ ] Add pagination helpers for historical/list endpoints.
 - [x] Migrate REST `Client` to async-first methods with explicit `_sync` convenience wrappers.
-- [ ] Harden `_sync` wrapper lifecycle after async-first migration; avoid or document cross-event-loop reuse of the underlying `httpx.AsyncClient`.
+- [x] Harden `_sync` wrapper lifecycle after async-first migration; avoid or document cross-event-loop reuse of the underlying `httpx.AsyncClient`.
 - [x] Replace generic `_sync` wrapper signatures with endpoint-specific parameters and return types for better IDE/type-checker support.
 - [x] Convert REST client tests toward native async style (`pytest.mark.anyio`) instead of relying mostly on `asyncio.run()` / `_sync` wrappers.
 - [ ] Add async pagination helpers / async iterators for historical and list endpoints, for example `async for order in client.iter_order_history(...)`.
-- [ ] Expand async lifecycle docs and examples, including `async with Client()`, `await client.aclose()`, `_sync` limitations in existing event loops, and a FastAPI dependency example.
+- [x] Expand async lifecycle docs and examples, including `async with Client()`, `await client.aclose()`, `_sync` limitations in existing event loops, and a FastAPI dependency example.
 
 ## Completed Milestones
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,34 @@ async with Client(api_key=..., api_secret=...) as client:  # private endpoints (
     raw = await client.request("GET", "/api/v3/...", auth=True)  # raw escape hatch
 ```
 
+`Client` owns an underlying `httpx.AsyncClient` by default. Prefer `async with Client(...)` so the HTTP session is closed automatically, or call `await client.aclose()` when managing the lifecycle manually.
+
+For small synchronous scripts, use the explicit `_sync` wrappers:
+
+```python
+from maicoin.v3 import Client
+
+ticker = Client().ticker_sync("btctwd")
+```
+
+Do not call `_sync` wrappers from code that already runs inside an event loop, such as FastAPI handlers, Jupyter notebooks, or async trading bots. Await the async methods there instead:
+
+```python
+from collections.abc import AsyncIterator
+
+from maicoin.v3 import Client
+
+
+async def max_client() -> AsyncIterator[Client]:
+    async with Client(api_key="...", api_secret="...") as client:
+        yield client
+
+
+async def handler(client: Client) -> dict[str, str]:
+    ticker = await client.ticker("btctwd")
+    return {"last": ticker.last}
+```
+
 > [!WARNING]
 > ⚠️ Private methods can place orders, transfer funds, take loans, and trigger withdrawals. Double-check arguments before calling state-changing methods against a live account.
 

--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -158,6 +158,17 @@ class Client:
 
     def _run_sync(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
         """Run one async REST method for synchronous scripts."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            msg = (
+                "Synchronous Client.*_sync wrappers cannot run inside an active event loop; "
+                "await the async method instead."
+            )
+            raise RuntimeError(msg)
+
         method = getattr(self, method_name)
         if not self._owns_session:
             return asyncio.run(method(*args, **kwargs))

--- a/tests/v3/test_client.py
+++ b/tests/v3/test_client.py
@@ -130,6 +130,13 @@ def test_request_sync_wrapper_runs_async_request() -> None:
     assert session.calls[-1]["url"] == "https://example.test/api/v3/ping"
 
 
+async def test_sync_wrappers_raise_inside_running_event_loop() -> None:
+    client = Client(session=FakeSession(FakeResponse({"timestamp": 1678766175})))
+
+    with pytest.raises(RuntimeError, match="cannot run inside an active event loop"):
+        client.timestamp_sync()
+
+
 def test_default_sync_wrappers_use_fresh_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
     sessions: list[FakeSession] = []
 


### PR DESCRIPTION
## Summary
- Add an explicit active-event-loop guard before `_sync` wrappers create coroutines
- Document async client lifecycle, manual `aclose()`, `_sync` limitations, and an async dependency-style example
- Mark the async lifecycle TODO items complete

## Tests
- `just`