### PR TITLE
feat(v3): add async pagination iterators

### DIFF
--- a/.agents/docs/TODO.md
+++ b/.agents/docs/TODO.md
@@ -10,12 +10,12 @@ Plan: [`plans/client-resilience-and-ergonomics-plan.md`](plans/client-resilience
 
 - [ ] Add WebSocket reconnect, heartbeat configuration, graceful cancellation, and non-blocking handler dispatch.
 - [ ] Add conservative REST retry/rate-limit support.
-- [ ] Add pagination helpers for historical/list endpoints.
+- [x] Add pagination helpers for historical/list endpoints.
 - [x] Migrate REST `Client` to async-first methods with explicit `_sync` convenience wrappers.
 - [x] Harden `_sync` wrapper lifecycle after async-first migration; avoid or document cross-event-loop reuse of the underlying `httpx.AsyncClient`.
 - [x] Replace generic `_sync` wrapper signatures with endpoint-specific parameters and return types for better IDE/type-checker support.
 - [x] Convert REST client tests toward native async style (`pytest.mark.anyio`) instead of relying mostly on `asyncio.run()` / `_sync` wrappers.
-- [ ] Add async pagination helpers / async iterators for historical and list endpoints, for example `async for order in client.iter_order_history(...)`.
+- [x] Add async pagination helpers / async iterators for historical and list endpoints, for example `async for order in client.iter_order_history(...)`.
 - [x] Expand async lifecycle docs and examples, including `async with Client()`, `await client.aclose()`, `_sync` limitations in existing event loops, and a FastAPI dependency example.
 
 ## Completed Milestones

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ async def handler(client: Client) -> dict[str, str]:
     return {"last": ticker.last}
 ```
 
+Use async iterators for cursor-paginated history endpoints:
+
+```python
+async with Client(api_key=..., api_secret=...) as client:
+    async for order in client.iter_order_history("btctwd", page_limit=100):
+        print(order.id, order.state)
+```
+
 > [!WARNING]
 > ⚠️ Private methods can place orders, transfer funds, take loans, and trigger withdrawals. Double-check arguments before calling state-changing methods against a live account.
 

--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -10,6 +10,8 @@ credentials. Every other method is authenticated and requires `api_key` /
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
+from collections.abc import Awaitable
 from collections.abc import Callable
 from collections.abc import Mapping
 from collections.abc import Sequence
@@ -67,6 +69,51 @@ DEFAULT_TIMEOUT = 10
 
 def _compact(params: Mapping[str, object | None]) -> dict[str, object]:
     return {key: value for key, value in params.items() if value is not None}
+
+
+async def _iter_id_paginated[PageItemT](  # noqa: C901
+    fetch_page: Callable[[int | None, int], Awaitable[Sequence[PageItemT]]],
+    item_id: Callable[[PageItemT], int],
+    *,
+    from_id: int | None,
+    page_limit: int,
+    max_items: int | None,
+    max_pages: int | None,
+) -> AsyncIterator[PageItemT]:
+    if page_limit <= 0:
+        msg = "page_limit must be greater than 0"
+        raise ValueError(msg)
+    if max_items == 0 or max_pages == 0:
+        return
+
+    cursor = from_id
+    yielded = 0
+    seen_ids: set[int] = set()
+    page_count = max_pages if max_pages is not None else 2**63
+
+    for page_number in range(page_count):
+        page = await fetch_page(cursor, page_limit)
+        if not page:
+            return
+
+        next_cursor = cursor
+        for item in page:
+            current_id = item_id(item)
+            if current_id in seen_ids:
+                continue
+            seen_ids.add(current_id)
+            yield item
+            yielded += 1
+            if max_items is not None and yielded >= max_items:
+                return
+            if next_cursor is None or current_id > next_cursor:
+                next_cursor = current_id
+
+        if len(page) < page_limit or page_number + 1 >= page_count:
+            return
+        if next_cursor == cursor:
+            return
+        cursor = next_cursor
 
 
 class RequestSession(Protocol):
@@ -792,6 +839,77 @@ class Client:
             auth=True,
         )
         return [Order.model_validate(item) for item in cast("list[object]", payload)]
+
+    async def iter_wallet_trades(
+        self,
+        *,
+        wallet_type: str = "spot",
+        market: str | None = None,
+        timestamp: int | None = None,
+        from_id: int | None = None,
+        order: str = "asc",
+        page_limit: int = 100,
+        max_items: int | None = None,
+        max_pages: int | None = None,
+    ) -> AsyncIterator[PrivateTrade]:
+        """Iterate wallet trades using the `from_id` cursor.
+
+        The iterator stops when the API returns an empty page, a page smaller
+        than `page_limit`, `max_pages` is reached, or `max_items` have been
+        yielded. Duplicate ids are skipped to protect callers from cursor
+        boundary overlap.
+        """
+
+        async def fetch_page(cursor: int | None, limit: int) -> Sequence[PrivateTrade]:
+            return await self.wallet_trades(
+                wallet_type=wallet_type,
+                market=market,
+                timestamp=timestamp,
+                from_id=cursor,
+                order=order,
+                limit=limit,
+            )
+
+        async for trade in _iter_id_paginated(
+            fetch_page,
+            lambda trade: trade.id,
+            from_id=from_id,
+            page_limit=page_limit,
+            max_items=max_items,
+            max_pages=max_pages,
+        ):
+            yield trade
+
+    async def iter_order_history(
+        self,
+        market: str,
+        *,
+        wallet_type: str = "spot",
+        from_id: int | None = None,
+        page_limit: int = 100,
+        max_items: int | None = None,
+        max_pages: int | None = None,
+    ) -> AsyncIterator[Order]:
+        """Iterate order history using the `from_id` cursor.
+
+        The iterator stops when the API returns an empty page, a page smaller
+        than `page_limit`, `max_pages` is reached, or `max_items` have been
+        yielded. Duplicate ids are skipped to protect callers from cursor
+        boundary overlap.
+        """
+
+        async def fetch_page(cursor: int | None, limit: int) -> Sequence[Order]:
+            return await self.order_history(market, wallet_type=wallet_type, from_id=cursor, limit=limit)
+
+        async for order_item in _iter_id_paginated(
+            fetch_page,
+            lambda order_item: order_item.id,
+            from_id=from_id,
+            page_limit=page_limit,
+            max_items=max_items,
+            max_pages=max_pages,
+        ):
+            yield order_item
 
     async def order(self, *, order_id: int | None = None, client_oid: str | None = None) -> Order:
         """Fetch a single order by `order_id` or `client_oid`."""

--- a/tests/v3/test_private.py
+++ b/tests/v3/test_private.py
@@ -40,7 +40,18 @@ class FakeSession:
         return self.response
 
 
-def last_kwargs(session: FakeSession) -> Mapping[str, object]:
+class PagedFakeSession:
+    def __init__(self, pages: list[object]) -> None:
+        self.pages = pages
+        self.calls: list[dict[str, object]] = []
+
+    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        page = self.pages[len(self.calls) - 1]
+        return FakeResponse(page)
+
+
+def last_kwargs(session: FakeSession | PagedFakeSession) -> Mapping[str, object]:
     return cast("Mapping[str, object]", session.calls[-1]["kwargs"])
 
 
@@ -50,7 +61,7 @@ def last_payload(session: FakeSession) -> Mapping[str, object]:
     return cast("Mapping[str, object]", json.loads(payload))
 
 
-def authenticated_client(session: FakeSession) -> Client:
+def authenticated_client(session: FakeSession | PagedFakeSession) -> Client:
     return Client(
         api_key="key",
         api_secret="secret",
@@ -79,6 +90,27 @@ def order_payload(**overrides: object) -> dict[str, object]:
         "trades_count": 0,
         "created_at": 1521726960123,
         "updated_at": 1521726960123,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def trade_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": 68444,
+        "order_id": 87,
+        "wallet_type": "spot",
+        "price": "21499.0",
+        "volume": "0.2658",
+        "funds": "5714.4",
+        "market": "ethtwd",
+        "market_name": "ETH/TWD",
+        "side": "bid",
+        "fee": "0.00001",
+        "fee_currency": "usdt",
+        "fee_discounted": False,
+        "liquidity": "taker",
+        "created_at": 1521726960357,
     }
     payload.update(overrides)
     return payload
@@ -144,26 +176,11 @@ async def test_open_closed_and_history_orders_parse_order_models() -> None:
 
 
 async def test_wallet_trades_constructs_authenticated_request_and_parses_private_trades() -> None:
-    trade_payload = {
-        "id": 68444,
-        "order_id": 87,
-        "wallet_type": "spot",
-        "price": "21499.0",
-        "volume": "0.2658",
-        "funds": "5714.4",
-        "market": "ethtwd",
-        "market_name": "ETH/TWD",
-        "side": "bid",
-        "fee": "0.00001",
-        "fee_currency": "usdt",
-        "fee_discounted": False,
-        "liquidity": "taker",
-        "created_at": 1521726960357,
-    }
-    session = FakeSession([trade_payload])
+    payload = trade_payload()
+    session = FakeSession([payload])
     trades = await authenticated_client(session).wallet_trades(market="ethtwd", from_id=68444, order="asc", limit=1)
 
-    assert trades == [PrivateTrade.model_validate(trade_payload)]
+    assert trades == [PrivateTrade.model_validate(payload)]
     assert session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/trades"
     assert last_kwargs(session)["params"] == {
         "nonce": 123456,
@@ -173,6 +190,75 @@ async def test_wallet_trades_constructs_authenticated_request_and_parses_private
         "limit": 1,
     }
     assert last_payload(session)["path"] == "/api/v3/wallet/spot/trades"
+
+
+async def test_iter_wallet_trades_advances_from_id_and_stops_at_max_items() -> None:
+    session = PagedFakeSession(
+        [
+            [trade_payload(id=1), trade_payload(id=2)],
+            [trade_payload(id=2), trade_payload(id=3)],
+        ]
+    )
+    client = authenticated_client(session)
+
+    trades = [trade async for trade in client.iter_wallet_trades(market="ethtwd", from_id=0, page_limit=2, max_items=3)]
+
+    assert [trade.id for trade in trades] == [1, 2, 3]
+    assert cast("Mapping[str, object]", session.calls[0]["kwargs"])["params"] == {
+        "nonce": 123456,
+        "market": "ethtwd",
+        "from_id": 0,
+        "order": "asc",
+        "limit": 2,
+    }
+    assert cast("Mapping[str, object]", session.calls[1]["kwargs"])["params"] == {
+        "nonce": 123456,
+        "market": "ethtwd",
+        "from_id": 2,
+        "order": "asc",
+        "limit": 2,
+    }
+
+
+async def test_iter_order_history_advances_from_id_until_short_page() -> None:
+    session = PagedFakeSession(
+        [
+            [order_payload(id=1), order_payload(id=2)],
+            [order_payload(id=3)],
+        ]
+    )
+    client = authenticated_client(session)
+
+    orders = [order async for order in client.iter_order_history("ethtwd", from_id=0, page_limit=2)]
+
+    assert [order.id for order in orders] == [1, 2, 3]
+    assert cast("Mapping[str, object]", session.calls[0]["kwargs"])["params"] == {
+        "nonce": 123456,
+        "market": "ethtwd",
+        "from_id": 0,
+        "limit": 2,
+    }
+    assert cast("Mapping[str, object]", session.calls[1]["kwargs"])["params"] == {
+        "nonce": 123456,
+        "market": "ethtwd",
+        "from_id": 2,
+        "limit": 2,
+    }
+
+
+async def test_iter_order_history_respects_max_pages() -> None:
+    session = PagedFakeSession(
+        [
+            [order_payload(id=1), order_payload(id=2)],
+            [order_payload(id=3), order_payload(id=4)],
+        ]
+    )
+    client = authenticated_client(session)
+
+    orders = [order async for order in client.iter_order_history("ethtwd", page_limit=2, max_pages=1)]
+
+    assert [order.id for order in orders] == [1, 2]
+    assert len(session.calls) == 1
 
 
 async def test_order_lookup_and_order_trades_construct_requests() -> None:


### PR DESCRIPTION
## Summary
- Add shared id-cursor pagination support for async iterators
- Add `iter_order_history()` and `iter_wallet_trades()` with `page_limit`, `max_items`, and `max_pages` controls
- Document the order-history iterator and mark pagination TODOs complete

## Tests
- `just`