### PR TITLE
Add client resilience controls

### DIFF
--- a/.agents/docs/TODO.md
+++ b/.agents/docs/TODO.md
@@ -8,8 +8,8 @@ Plan archived: [`archived/live-integration-tests-plan.md`](archived/live-integra
 
 Plan: [`plans/client-resilience-and-ergonomics-plan.md`](plans/client-resilience-and-ergonomics-plan.md)
 
-- [ ] Add WebSocket reconnect, heartbeat configuration, graceful cancellation, and non-blocking handler dispatch.
-- [ ] Add conservative REST retry/rate-limit support.
+- [x] Add WebSocket reconnect, heartbeat configuration, graceful cancellation, and non-blocking handler dispatch.
+- [x] Add conservative REST retry/rate-limit support.
 - [x] Add pagination helpers for historical/list endpoints.
 - [x] Migrate REST `Client` to async-first methods with explicit `_sync` convenience wrappers.
 - [x] Harden `_sync` wrapper lifecycle after async-first migration; avoid or document cross-event-loop reuse of the underlying `httpx.AsyncClient`.

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -23,20 +23,23 @@ ticker = client.ticker_sync("btctwd")
 
 `_sync` wrappers use `asyncio.run()`, so code already running in an event loop should call the async methods directly.
 
-You can override the base URL, timeout, or HTTP session if needed:
+You can override the base URL, timeout, retry policy, or HTTP session if needed:
 
 ```python
 import httpx
-from maicoin.v3 import Client
+from maicoin.v3 import Client, RetryPolicy
 
 client = Client(
     api_key="...",
     api_secret="...",
     base_url="https://max-api.maicoin.com",
     timeout=10,
+    retry_policy=RetryPolicy(total_attempts=3),
     session=httpx.AsyncClient(),
 )
 ```
+
+Retries are conservative by default: only idempotent methods (`GET`, `HEAD`, `OPTIONS`) retry transient `429`, `502`, `503`, and `504` responses or network/timeout failures. `Retry-After` is respected when present. State-changing methods such as order placement and withdrawals are not retried unless you explicitly opt in with `RetryPolicy(retry_non_idempotent=True)`.
 
 ## Public endpoints
 

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -42,7 +42,7 @@ Or pass them explicitly:
 stream = Stream(api_key="...", api_secret="...")
 ```
 
-## Handlers
+## Handlers and dispatch modes
 
 Handlers receive a fully validated [`Response`][maicoin.ws.Response]. You can attach as many handlers as you like:
 
@@ -53,6 +53,36 @@ def on_response(response):
 
 stream.add_handler(on_response)
 ```
+
+`Stream` supports three dispatch modes:
+
+- `inline` (default): call/await handlers before reading the next message. This preserves strict ordering.
+- `task`: schedule each handler with `asyncio.create_task()`. This keeps slow async handlers from blocking the receive loop, but ordering is not guaranteed.
+- `queue`: put responses into `stream.response_queue` for consumer-managed processing; registered handlers are ignored.
+
+```python
+stream = Stream(dispatch="task", on_handler_error=lambda exc, response: print(exc))
+
+queue_stream = Stream(dispatch="queue")
+# elsewhere: response = await queue_stream.response_queue.get()
+```
+
+## Reconnects and heartbeat options
+
+By default, `Stream` reconnects after transient disconnects and replays queued auth/subscription requests. Configure backoff with [`ReconnectPolicy`][maicoin.ws.ReconnectPolicy], or disable reconnects with `reconnect=False`:
+
+```python
+from maicoin.ws import ReconnectPolicy
+
+stream = Stream(
+    reconnect_policy=ReconnectPolicy(max_retries=10, base_delay=1, max_delay=30),
+    ping_interval=20,
+    ping_timeout=20,
+    close_timeout=5,
+)
+```
+
+Extra keyword arguments are forwarded to `websockets.connect`, including heartbeat and queue options such as `ping_interval`, `ping_timeout`, `close_timeout`, and `max_queue`.
 
 ## Async usage
 

--- a/src/maicoin/v3/__init__.py
+++ b/src/maicoin/v3/__init__.py
@@ -5,6 +5,7 @@ from maicoin.v3.auth import sign_payload
 from maicoin.v3.client import BASE_URL
 from maicoin.v3.client import DEFAULT_TIMEOUT
 from maicoin.v3.client import Client
+from maicoin.v3.client import RetryPolicy
 from maicoin.v3.errors import MaxAPIError
 from maicoin.v3.errors import MaxHTTPError
 from maicoin.v3.models import Account
@@ -84,6 +85,7 @@ __all__ = [
     "OrderType",
     "PrivateTrade",
     "PublicTrade",
+    "RetryPolicy",
     "Reward",
     "Staking",
     "Ticker",

--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -10,11 +10,16 @@ credentials. Every other method is authenticated and requires `api_key` /
 from __future__ import annotations
 
 import asyncio
+import email.utils
+import random
 from collections.abc import AsyncIterator
 from collections.abc import Awaitable
 from collections.abc import Callable
 from collections.abc import Mapping
 from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC
+from datetime import datetime
 from typing import Any
 from typing import Protocol
 from typing import cast
@@ -65,6 +70,55 @@ BASE_URL = "https://max-api.maicoin.com"
 
 DEFAULT_TIMEOUT = 10
 """Default per-request timeout in seconds."""
+
+SAFE_RETRY_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Conservative retry/rate-limit policy for REST requests.
+
+    By default only idempotent public/read requests (`GET`, `HEAD`, `OPTIONS`)
+    are retried. Private write endpoints can opt in with
+    `retry_non_idempotent=True` when the caller has an idempotency strategy such
+    as stable client order ids.
+    """
+
+    enabled: bool = True
+    total_attempts: int = 3
+    backoff_factor: float = 0.5
+    max_delay: float = 10.0
+    jitter: float = 0.25
+    status_codes: frozenset[int] = frozenset({429, 502, 503, 504})
+    retry_timeouts: bool = True
+    retry_network_errors: bool = True
+    retry_non_idempotent: bool = False
+    respect_retry_after: bool = True
+
+    def allows_method(self, method: str) -> bool:
+        return method.upper() in SAFE_RETRY_METHODS or self.retry_non_idempotent
+
+    def delay(self, attempt_index: int) -> float:
+        delay = min(self.max_delay, self.backoff_factor * 2 ** max(0, attempt_index - 1))
+        if self.jitter <= 0:
+            return delay
+        return delay + random.uniform(0, self.jitter)
+
+
+def _retry_after_delay(value: str | None) -> float | None:
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        pass
+    try:
+        retry_at = email.utils.parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=UTC)
+    return max(0.0, (retry_at - datetime.now(UTC)).total_seconds())
 
 
 def _compact(params: Mapping[str, object | None]) -> dict[str, object]:
@@ -155,6 +209,7 @@ class Client:
         timeout: float = DEFAULT_TIMEOUT,
         session: RequestSession | None = None,
         nonce_factory: Callable[[], int] = generate_nonce,
+        retry_policy: RetryPolicy | None = None,
     ) -> None:
         """Build a REST v3 client.
 
@@ -167,6 +222,8 @@ class Client:
                 Defaults to a fresh `httpx.AsyncClient`.
             nonce_factory: Callable returning a strictly increasing integer
                 nonce in milliseconds. Override in tests.
+            retry_policy: Retry/backoff policy for transient failures. Pass
+                `RetryPolicy(enabled=False)` to disable retries.
         """
         self.api_key = api_key
         self.api_secret = api_secret
@@ -175,6 +232,7 @@ class Client:
         self._owns_session = session is None
         self._session: RequestSession | None = session
         self.nonce_factory = nonce_factory
+        self.retry_policy = retry_policy or RetryPolicy()
 
     @property
     def session(self) -> RequestSession:
@@ -652,7 +710,7 @@ class Client:
         else:
             kwargs["json"] = request_params
 
-        response = await self.session.request(normalized_method, url, **kwargs)
+        response = await self._request_with_retries(normalized_method, url, kwargs)
         raise_for_response_status(response)
         if not response.content:
             return None
@@ -660,6 +718,46 @@ class Client:
         payload = response.json()
         raise_for_api_error(payload)
         return payload
+
+    async def _request_with_retries(self, method: str, url: str, kwargs: Mapping[str, object]) -> Response:
+        policy = self.retry_policy
+        attempts = max(1, policy.total_attempts)
+        retry_allowed = policy.enabled and policy.allows_method(method) and attempts > 1
+        last_exc: httpx.TimeoutException | httpx.TransportError | None = None
+
+        for attempt_index in range(1, attempts + 1):
+            try:
+                response = await self.session.request(method, url, **dict(kwargs))
+            except httpx.TimeoutException as exc:
+                last_exc = exc
+                if not (retry_allowed and policy.retry_timeouts and attempt_index < attempts):
+                    raise
+                await self._sleep_before_retry(policy.delay(attempt_index))
+                continue
+            except httpx.TransportError as exc:
+                last_exc = exc
+                if not (retry_allowed and policy.retry_network_errors and attempt_index < attempts):
+                    raise
+                await self._sleep_before_retry(policy.delay(attempt_index))
+                continue
+
+            if not (retry_allowed and response.status_code in policy.status_codes and attempt_index < attempts):
+                return response
+
+            retry_after = None
+            if policy.respect_retry_after:
+                headers = getattr(response, "headers", None)
+                retry_after = _retry_after_delay(headers.get("Retry-After") if headers is not None else None)
+            await self._sleep_before_retry(retry_after if retry_after is not None else policy.delay(attempt_index))
+
+        if last_exc is not None:
+            raise last_exc
+        msg = "request retry loop exhausted without a response"
+        raise RuntimeError(msg)
+
+    async def _sleep_before_retry(self, delay: float) -> None:
+        if delay > 0:
+            await asyncio.sleep(delay)
 
     async def markets(self) -> list[Market]:
         """List all available markets (`GET /api/v3/markets`)."""

--- a/src/maicoin/ws/__init__.py
+++ b/src/maicoin/ws/__init__.py
@@ -14,6 +14,7 @@ from maicoin.ws.request import Request
 from maicoin.ws.response import Event
 from maicoin.ws.response import Response
 from maicoin.ws.side import Side
+from maicoin.ws.stream import ReconnectPolicy
 from maicoin.ws.stream import Stream
 from maicoin.ws.subscription import Subscription
 from maicoin.ws.ticker import Ticker
@@ -33,6 +34,7 @@ __all__ = [
     "OrderState",
     "OrderType",
     "PoolQuota",
+    "ReconnectPolicy",
     "Request",
     "Response",
     "Side",

--- a/src/maicoin/ws/stream.py
+++ b/src/maicoin/ws/stream.py
@@ -1,15 +1,23 @@
 """WebSocket stream client for the [MaiCoin MAX WebSocket API](https://maicoin.github.io/max-websocket-docs/).
 
-The client opens a single connection, queues subscription/auth requests, and
-dispatches each incoming message to every registered handler as a typed
-[`Response`][maicoin.ws.Response].
+The client opens a connection, queues subscription/auth requests, and dispatches
+incoming messages to registered handlers as typed [`Response`][maicoin.ws.Response]
+objects. It can also reconnect with backoff and replay queued requests after a
+transient disconnect.
 """
 
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
+import random
+from collections.abc import Awaitable
 from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+from typing import Protocol
+from typing import cast
 
 import websockets
 
@@ -20,6 +28,61 @@ from maicoin.ws.subscription import Subscription
 MAX_WS_URI = os.getenv("MAX_WS_URI", "wss://max-stream.maicoin.com/ws")
 """WebSocket endpoint. Override with the `MAX_WS_URI` env var (e.g. for staging)."""
 
+DispatchMode = Literal["inline", "task", "queue"]
+"""Response dispatch strategy used by [`Stream`][maicoin.ws.Stream]."""
+
+Handler = Callable[[Response], object | Awaitable[object]]
+LifecycleCallback = Callable[[Exception | None], object | Awaitable[object]]
+HandlerErrorCallback = Callable[[Exception, Response], object | Awaitable[object]]
+
+
+class WebSocketConnection(Protocol):
+    """Minimal async websocket connection protocol used by [`Stream`][maicoin.ws.Stream]."""
+
+    async def send(self, message: str) -> None: ...
+
+    async def recv(self) -> str | bytes: ...
+
+    async def close(self) -> None: ...
+
+
+class WebSocketContext(Protocol):
+    """Async context manager returned by websocket connect factories."""
+
+    async def __aenter__(self) -> WebSocketConnection: ...
+
+    async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None: ...
+
+
+ConnectFactory = Callable[..., WebSocketContext]
+
+
+@dataclass(frozen=True)
+class ReconnectPolicy:
+    """Reconnect/backoff configuration for [`Stream`][maicoin.ws.Stream].
+
+    Args:
+        enabled: Whether to reconnect after non-cancellation disconnects.
+        max_retries: Maximum reconnect attempts after the initial connection.
+            `None` retries forever.
+        base_delay: Initial backoff delay in seconds.
+        max_delay: Maximum backoff delay in seconds.
+        jitter: Random delay added to each backoff, in seconds.
+    """
+
+    enabled: bool = True
+    max_retries: int | None = None
+    base_delay: float = 1.0
+    max_delay: float = 30.0
+    jitter: float = 1.0
+
+    def delay(self, retry_number: int) -> float:
+        """Return the reconnect delay for a 1-based retry number."""
+        backoff = min(self.max_delay, self.base_delay * 2 ** max(0, retry_number - 1))
+        if self.jitter <= 0:
+            return backoff
+        return backoff + random.uniform(0, self.jitter)
+
 
 class Stream:
     """Synchronous-style wrapper around the MAX WebSocket connection.
@@ -28,50 +91,85 @@ class Stream:
     [`add_handler`][maicoin.ws.Stream.add_handler] as many times as you like,
     then call [`run`][maicoin.ws.Stream.run] to block on the event loop.
 
-    Examples:
-        Public channels only:
-
-        >>> from maicoin.ws import Channel, Stream, Subscription
-        >>> stream = Stream()
-        >>> stream.subscribe([Subscription(channel=Channel.TICKER, market="btcusdt")])
-        >>> stream.add_handler(lambda r: print(r.event))
-        >>> stream.run()  # doctest: +SKIP
-
-        Private channels (auth):
-
-        >>> stream = Stream.from_env()  # doctest: +SKIP
+    Dispatch modes:
+        * `inline`: await/call handlers before reading the next websocket message.
+        * `task`: schedule handlers with `asyncio.create_task` so slow async
+          handlers do not block the receive loop.
+        * `queue`: put parsed responses into `response_queue` for consumer-owned
+          processing; registered handlers are not invoked.
     """
 
     requests: list[Request]
-    """Pending requests sent in order on connect (auth first if configured)."""
+    """Pending requests sent in order on every connect (auth first if configured)."""
 
-    handlers: list[Callable]
+    handlers: list[Handler]
     """Callbacks invoked with each parsed [`Response`][maicoin.ws.Response]."""
 
     def __init__(
         self,
         api_key: str | None = None,
         api_secret: str | None = None,
+        *,
+        uri: str = MAX_WS_URI,
+        reconnect: bool = True,
+        reconnect_policy: ReconnectPolicy | None = None,
+        dispatch: DispatchMode = "inline",
+        response_queue: asyncio.Queue[Response] | None = None,
+        connect_factory: ConnectFactory | None = None,
+        on_connected: LifecycleCallback | None = None,
+        on_disconnected: LifecycleCallback | None = None,
+        on_reconnecting: LifecycleCallback | None = None,
+        on_permanent_failure: LifecycleCallback | None = None,
+        on_handler_error: HandlerErrorCallback | None = None,
+        **connect_options: object,
     ) -> None:
         """Build a stream.
-
-        When both credentials are provided, an auth request is queued ahead of
-        any subscription requests so private channels can be used.
 
         Args:
             api_key: MAX API access key. Required for private channels.
             api_secret: MAX API secret. Required for private channels.
+            uri: WebSocket endpoint.
+            reconnect: Convenience switch for reconnects. Ignored when
+                `reconnect_policy` is provided.
+            reconnect_policy: Backoff/retry settings.
+            dispatch: Handler dispatch strategy: `inline`, `task`, or `queue`.
+            response_queue: Queue used by `dispatch="queue"`. Created lazily
+                when omitted.
+            connect_factory: Injectable `websockets.connect`-compatible factory.
+            on_connected: Optional lifecycle callback after queued requests are sent.
+            on_disconnected: Optional lifecycle callback after a disconnect.
+            on_reconnecting: Optional lifecycle callback before sleeping/retrying.
+            on_permanent_failure: Optional lifecycle callback before giving up.
+            on_handler_error: Optional callback for handler exceptions.
+            **connect_options: Extra options forwarded to `websockets.connect`,
+                such as `ping_interval`, `ping_timeout`, `close_timeout`, and `max_queue`.
         """
+        if dispatch not in {"inline", "task", "queue"}:
+            msg = "dispatch must be 'inline', 'task', or 'queue'"
+            raise ValueError(msg)
+
         self.requests = []
         self.handlers = []
+        self.uri = uri
+        self.reconnect_policy = reconnect_policy or ReconnectPolicy(enabled=reconnect)
+        self.dispatch: DispatchMode = dispatch
+        self.response_queue = response_queue if response_queue is not None else asyncio.Queue()
+        self.connect_factory = connect_factory or cast("ConnectFactory", websockets.connect)
+        self.connect_options = connect_options
+        self.on_connected = on_connected
+        self.on_disconnected = on_disconnected
+        self.on_reconnecting = on_reconnecting
+        self.on_permanent_failure = on_permanent_failure
+        self.on_handler_error = on_handler_error
+        self._handler_tasks: set[asyncio.Task[object]] = set()
 
         self.auth(api_key, api_secret)
 
     def subscribe(self, subscriptions: list[Subscription]) -> None:
         """Queue a `subscribe` request for the given list of subscriptions.
 
-        May be called multiple times; each call sends one `sub` request on
-        connect.
+        May be called multiple times; each call sends one `sub` request on each
+        connection, including after reconnect.
         """
         self.requests += [Request.subscribe(subscriptions)]
 
@@ -86,7 +184,22 @@ class Stream:
             self.requests += [Request.auth(api_key, api_secret)]
 
     @classmethod
-    def from_env(cls) -> Stream:
+    def from_env(
+        cls,
+        *,
+        uri: str = MAX_WS_URI,
+        reconnect: bool = True,
+        reconnect_policy: ReconnectPolicy | None = None,
+        dispatch: DispatchMode = "inline",
+        response_queue: asyncio.Queue[Response] | None = None,
+        connect_factory: ConnectFactory | None = None,
+        on_connected: LifecycleCallback | None = None,
+        on_disconnected: LifecycleCallback | None = None,
+        on_reconnecting: LifecycleCallback | None = None,
+        on_permanent_failure: LifecycleCallback | None = None,
+        on_handler_error: HandlerErrorCallback | None = None,
+        **connect_options: object,
+    ) -> Stream:
         """Build a stream using `MAX_API_KEY` / `MAX_API_SECRET` from the environment.
 
         Raises:
@@ -100,7 +213,22 @@ class Stream:
         if not api_secret:
             raise ValueError("MAX_API_SECRET is not set")
 
-        return cls(api_key=api_key, api_secret=api_secret)
+        return cls(
+            api_key=api_key,
+            api_secret=api_secret,
+            uri=uri,
+            reconnect=reconnect,
+            reconnect_policy=reconnect_policy,
+            dispatch=dispatch,
+            response_queue=response_queue,
+            connect_factory=connect_factory,
+            on_connected=on_connected,
+            on_disconnected=on_disconnected,
+            on_reconnecting=on_reconnecting,
+            on_permanent_failure=on_permanent_failure,
+            on_handler_error=on_handler_error,
+            **connect_options,
+        )
 
     def run(self) -> None:
         """Connect and dispatch messages until cancelled.
@@ -112,21 +240,87 @@ class Stream:
         asyncio.run(self.arun())
 
     async def arun(self) -> None:
-        """Async entry point: connect, send queued requests, and dispatch responses forever."""
-        async with websockets.connect(MAX_WS_URI) as ws:
-            for req in self.requests:
-                await ws.send(req.message())
+        """Async entry point: connect, replay queued requests, and dispatch responses forever."""
+        retry_count = 0
+        while True:
+            try:
+                async with self.connect_factory(self.uri, **self.connect_options) as ws:
+                    retry_count = 0
+                    for req in self.requests:
+                        await ws.send(req.message())
+                    await self._call_lifecycle(self.on_connected, None)
 
-            while True:
-                data = await ws.recv()
-                resp = Response.model_validate_json(data)
-                for handler in self.handlers:
-                    handler(resp)
+                    while True:
+                        data = await ws.recv()
+                        resp = Response.model_validate_json(data)
+                        await self._dispatch(resp)
+            except asyncio.CancelledError:
+                await self._cancel_handler_tasks()
+                raise
+            except Exception as exc:
+                await self._call_lifecycle(self.on_disconnected, exc)
+                retry_count += 1
+                if not self._should_reconnect(retry_count):
+                    await self._call_lifecycle(self.on_permanent_failure, exc)
+                    raise
+                await self._call_lifecycle(self.on_reconnecting, exc)
+                delay = self.reconnect_policy.delay(retry_count)
+                if delay > 0:
+                    await asyncio.sleep(delay)
 
-    def add_handler(self, handler: Callable) -> None:
+    def add_handler(self, handler: Handler) -> None:
         """Register a callback invoked with each [`Response`][maicoin.ws.Response].
 
-        Handlers run in registration order. They should be cheap and
-        non-blocking — heavy work belongs in a background task or queue.
+        In `inline` mode handlers run in registration order. In `task` mode each
+        handler is scheduled independently; ordering is not guaranteed. In
+        `queue` mode registered handlers are ignored and responses are written to
+        [`response_queue`][maicoin.ws.Stream.response_queue].
         """
         self.handlers.append(handler)
+
+    def _should_reconnect(self, retry_count: int) -> bool:
+        policy = self.reconnect_policy
+        if not policy.enabled:
+            return False
+        return policy.max_retries is None or retry_count <= policy.max_retries
+
+    async def _dispatch(self, resp: Response) -> None:
+        if self.dispatch == "queue":
+            await self.response_queue.put(resp)
+            return
+
+        for handler in self.handlers:
+            if self.dispatch == "task":
+                task = asyncio.create_task(self._call_handler(handler, resp))
+                self._handler_tasks.add(task)
+                task.add_done_callback(self._handler_tasks.discard)
+            else:
+                await self._call_handler(handler, resp)
+
+    async def _call_handler(self, handler: Handler, resp: Response) -> None:
+        try:
+            result = handler(resp)
+            if inspect.isawaitable(result):
+                await result
+        except Exception as exc:
+            if self.on_handler_error is None:
+                if self.dispatch == "inline":
+                    raise
+                return
+            result = self.on_handler_error(exc, resp)
+            if inspect.isawaitable(result):
+                await result
+
+    async def _call_lifecycle(self, callback: LifecycleCallback | None, exc: Exception | None) -> None:
+        if callback is None:
+            return
+        result = callback(exc)
+        if inspect.isawaitable(result):
+            await result
+
+    async def _cancel_handler_tasks(self) -> None:
+        for task in self._handler_tasks:
+            task.cancel()
+        if self._handler_tasks:
+            await asyncio.gather(*self._handler_tasks, return_exceptions=True)
+        self._handler_tasks.clear()

--- a/tests/v3/test_client.py
+++ b/tests/v3/test_client.py
@@ -6,6 +6,7 @@ from typing import cast
 import pytest
 
 from maicoin.v3.client import Client
+from maicoin.v3.client import RetryPolicy
 from maicoin.v3.errors import MaxAPIError
 from maicoin.v3.errors import MaxHTTPError
 
@@ -13,9 +14,10 @@ pytestmark = pytest.mark.anyio
 
 
 class FakeResponse:
-    def __init__(self, payload: object, *, status_code: int = 200) -> None:
+    def __init__(self, payload: object, *, status_code: int = 200, headers: Mapping[str, str] | None = None) -> None:
         self.payload = payload
         self.status_code = status_code
+        self.headers = dict(headers or {})
         self.content = b"{}"
         self.text = str(payload)
 
@@ -24,14 +26,16 @@ class FakeResponse:
 
 
 class FakeSession:
-    def __init__(self, response: FakeResponse) -> None:
-        self.response = response
+    def __init__(self, response: FakeResponse | list[FakeResponse]) -> None:
+        self.responses = [response] if isinstance(response, FakeResponse) else response
         self.calls: list[dict[str, object]] = []
         self.closed = False
 
     async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
         self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-        return self.response
+        if len(self.responses) == 1:
+            return self.responses[0]
+        return self.responses.pop(0)
 
     async def aclose(self) -> None:
         self.closed = True
@@ -120,6 +124,63 @@ async def test_authenticated_request_requires_credentials() -> None:
 
     with pytest.raises(ValueError, match="api_key and api_secret"):
         await client.request("GET", "/api/v3/wallet/spot/accounts", auth=True)
+
+
+async def test_get_request_retries_retry_after_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+
+    async def sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    session = FakeSession(
+        [
+            FakeResponse({"error": "rate limited"}, status_code=429, headers={"Retry-After": "0"}),
+            FakeResponse({"ok": True}),
+        ]
+    )
+    client = Client(base_url="https://example.test", session=session, retry_policy=RetryPolicy(jitter=0))
+    monkeypatch.setattr(client, "_sleep_before_retry", sleep)
+
+    assert await client.request("GET", "/api/v3/ping") == {"ok": True}
+    assert len(session.calls) == 2
+    assert sleeps == [0.0]
+
+
+async def test_post_request_does_not_retry_by_default() -> None:
+    session = FakeSession(
+        [
+            FakeResponse({"error": "gateway"}, status_code=503),
+            FakeResponse({"ok": True}),
+        ]
+    )
+    client = Client(base_url="https://example.test", session=session, retry_policy=RetryPolicy(jitter=0))
+
+    with pytest.raises(MaxHTTPError, match="gateway"):
+        await client.request("POST", "/api/v3/order", params={"market": "btctwd"})
+
+    assert len(session.calls) == 1
+
+
+async def test_post_request_retries_when_non_idempotent_opted_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = FakeSession(
+        [
+            FakeResponse({"error": "gateway"}, status_code=503),
+            FakeResponse({"ok": True}),
+        ]
+    )
+    client = Client(
+        base_url="https://example.test",
+        session=session,
+        retry_policy=RetryPolicy(retry_non_idempotent=True, backoff_factor=0, jitter=0),
+    )
+
+    async def sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(client, "_sleep_before_retry", sleep)
+
+    assert await client.request("POST", "/api/v3/order", params={"market": "btctwd"}) == {"ok": True}
+    assert len(session.calls) == 2
 
 
 def test_request_sync_wrapper_runs_async_request() -> None:

--- a/tests/ws/conftest.py
+++ b/tests/ws/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Run AnyIO-marked WebSocket tests on asyncio only."""
+    return "asyncio"

--- a/tests/ws/test_stream.py
+++ b/tests/ws/test_stream.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from collections.abc import Iterator
+
+import pytest
+
+from maicoin.ws import Channel
+from maicoin.ws import ReconnectPolicy
+from maicoin.ws import Response
+from maicoin.ws import Stream
+from maicoin.ws import Subscription
+
+MESSAGE = '{"e":"subscribed","s":[{"channel":"trade","market":"btctwd"}],"i":"client1","T":123456789}'
+
+
+class FakeConnection:
+    def __init__(self, messages: list[str | BaseException]) -> None:
+        self.messages = messages
+        self.sent: list[str] = []
+        self.closed = False
+
+    async def send(self, message: str) -> None:
+        self.sent.append(message)
+
+    async def recv(self) -> str:
+        item = self.messages.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeContext:
+    def __init__(self, connection: FakeConnection) -> None:
+        self.connection = connection
+
+    async def __aenter__(self) -> FakeConnection:
+        return self.connection
+
+    async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        return None
+
+
+def connect_factory(connections: list[FakeConnection]) -> Callable[..., FakeContext]:
+    iterator: Iterator[FakeConnection] = iter(connections)
+
+    def connect(*_args: object, **_kwargs: object) -> FakeContext:
+        return FakeContext(next(iterator))
+
+    return connect
+
+
+@pytest.mark.anyio
+async def test_stream_reconnects_and_replays_subscriptions() -> None:
+    first = FakeConnection([ConnectionError("dropped")])
+    second = FakeConnection([MESSAGE, asyncio.CancelledError()])
+    seen: list[Response] = []
+    events: list[str] = []
+    stream = Stream(
+        reconnect_policy=ReconnectPolicy(max_retries=1, base_delay=0, jitter=0),
+        connect_factory=connect_factory([first, second]),
+        on_disconnected=lambda _exc: events.append("disconnected"),
+        on_reconnecting=lambda _exc: events.append("reconnecting"),
+    )
+    stream.subscribe([Subscription(channel=Channel.TRADE, market="btctwd")])
+    stream.add_handler(seen.append)
+
+    with pytest.raises(asyncio.CancelledError):
+        await stream.arun()
+
+    assert len(first.sent) == 1
+    assert first.sent == second.sent
+    assert [response.event for response in seen] == ["subscribed"]
+    assert events == ["disconnected", "reconnecting"]
+
+
+@pytest.mark.anyio
+async def test_stream_queue_dispatch_does_not_call_handlers() -> None:
+    connection = FakeConnection([MESSAGE, asyncio.CancelledError()])
+    stream = Stream(
+        reconnect=False,
+        dispatch="queue",
+        connect_factory=connect_factory([connection]),
+    )
+
+    def fail_handler(_response: Response) -> None:
+        raise AssertionError("queue dispatch should not call registered handlers")
+
+    stream.add_handler(fail_handler)
+
+    with pytest.raises(asyncio.CancelledError):
+        await stream.arun()
+
+    response = stream.response_queue.get_nowait()
+    assert response.event == "subscribed"
+
+
+@pytest.mark.anyio
+async def test_stream_task_dispatch_reports_handler_errors_without_stopping_receive_loop() -> None:
+    connection = FakeConnection([MESSAGE, MESSAGE, ConnectionError("closed")])
+    errors: list[tuple[Exception, Response]] = []
+    seen: list[str] = []
+
+    async def bad_handler(response: Response) -> None:
+        seen.append(response.event)
+        raise RuntimeError("boom")
+
+    stream = Stream(
+        reconnect=False,
+        dispatch="task",
+        connect_factory=connect_factory([connection]),
+        on_handler_error=lambda exc, response: errors.append((exc, response)),
+    )
+    stream.add_handler(bad_handler)
+
+    with pytest.raises(ConnectionError):
+        await stream.arun()
+
+    await asyncio.sleep(0)
+    assert seen == ["subscribed", "subscribed"]
+    assert [response.event for _exc, response in errors] == ["subscribed", "subscribed"]
+
+
+def test_stream_forwards_websocket_connect_options() -> None:
+    captured: dict[str, object] = {}
+
+    def connect(*args: object, **kwargs: object) -> FakeContext:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return FakeContext(FakeConnection([asyncio.CancelledError()]))
+
+    stream = Stream(
+        uri="wss://example.invalid/ws",
+        reconnect=False,
+        connect_factory=connect,
+        ping_interval=10,
+        ping_timeout=5,
+        close_timeout=2,
+        max_queue=16,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(stream.arun())
+
+    assert captured == {
+        "args": ("wss://example.invalid/ws",),
+        "kwargs": {"ping_interval": 10, "ping_timeout": 5, "close_timeout": 2, "max_queue": 16},
+    }


### PR DESCRIPTION
## Summary
- add WebSocket reconnect policy, heartbeat/connect options, lifecycle callbacks, and inline/task/queue dispatch modes
- add conservative REST retry policy with Retry-After support and opt-in non-idempotent retries
- document the new resilience controls and mark the client resilience TODOs complete

## Tests
- just