### PR TITLE
docs: archive client resilience plan

### DIFF
--- a/.agents/docs/TODO.md
+++ b/.agents/docs/TODO.md
@@ -1,32 +1,46 @@
 # TODO
 
-## Live Integration Tests
+## Active Follow-Ups
 
-Plan archived: [`archived/live-integration-tests-plan.md`](archived/live-integration-tests-plan.md). Read-only public and private live tests are implemented; destructive live tests remain intentionally out of scope until a separate design pass.
+Follow-up plan: [`plans/client-resilience-and-ergonomics-plan.md`](plans/client-resilience-and-ergonomics-plan.md)
 
-## Client Resilience and Ergonomics
+### Destructive Live Tests
 
-Plan: [`plans/client-resilience-and-ergonomics-plan.md`](plans/client-resilience-and-ergonomics-plan.md)
+Plan archived: [`archived/live-integration-tests-plan.md`](archived/live-integration-tests-plan.md). Read-only public and private live tests are implemented; destructive live tests remain intentionally out of scope until a separate safety design pass.
+
+- [ ] Design opt-in destructive live tests with explicit environment gates, balance checks, cleanup, and manual recovery steps.
+
+### Dataclass Low-Level Model Experiment
+
+Plan archived: [`archived/dataclass-low-level-models-plan.md`](archived/dataclass-low-level-models-plan.md).
+
+- [ ] Revisit low-level dataclass models only if fresh benchmark evidence shows value and there is a compatibility migration path.
+
+## Completed Milestones
+
+### Client Resilience and Ergonomics
+
+Archived plan: [`archived/client-resilience-and-ergonomics-plan.md`](archived/client-resilience-and-ergonomics-plan.md)
 
 - [x] Add WebSocket reconnect, heartbeat configuration, graceful cancellation, and non-blocking handler dispatch.
 - [x] Add conservative REST retry/rate-limit support.
 - [x] Add pagination helpers for historical/list endpoints.
 - [x] Migrate REST `Client` to async-first methods with explicit `_sync` convenience wrappers.
-- [x] Harden `_sync` wrapper lifecycle after async-first migration; avoid or document cross-event-loop reuse of the underlying `httpx.AsyncClient`.
+- [x] Harden `_sync` wrapper lifecycle after async-first migration; avoid cross-event-loop reuse of the underlying `httpx.AsyncClient`.
 - [x] Replace generic `_sync` wrapper signatures with endpoint-specific parameters and return types for better IDE/type-checker support.
 - [x] Convert REST client tests toward native async style (`pytest.mark.anyio`) instead of relying mostly on `asyncio.run()` / `_sync` wrappers.
 - [x] Add async pagination helpers / async iterators for historical and list endpoints, for example `async for order in client.iter_order_history(...)`.
 - [x] Expand async lifecycle docs and examples, including `async with Client()`, `await client.aclose()`, `_sync` limitations in existing event loops, and a FastAPI dependency example.
 
-## Completed Milestones
+### REST v3 and WebSocket API Coverage
 
-- REST v3 foundation, public endpoints, private order/trade/account endpoints, wallet funds, convert, and M-Wallet private endpoints.
-- WebSocket public/private gap cleanup, including M-Wallet pool quota/private channels, book update ids, unsubscribe serialization, and string-preserving numeric payload fields.
-- README REST v3 examples and official API documentation links in `AGENTS.md`.
-- Live integration tests plan documented in `docs/live-integration-tests-plan.md`.
+- [x] REST v3 foundation, public endpoints, private order/trade/account endpoints, wallet funds, convert, and M-Wallet private endpoints.
+- [x] WebSocket public/private gap cleanup, including M-Wallet pool quota/private channels, book update ids, unsubscribe serialization, and string-preserving numeric payload fields.
+- [x] README REST v3 examples and official API documentation links in `AGENTS.md`.
+- [x] Read-only live integration tests.
 
 ## Verification
 
-- `just` passed after Phase 7 WebSocket cleanup.
-- Tests currently use mocked sessions/payloads and do not depend on real MAX API credentials.
+- Client resilience and ergonomics landed via PR #62 / commit `1ae3b73 feat: add client resilience controls` and related prior PRs.
+- Tests use mocked sessions/payloads for normal runs and do not depend on real MAX API credentials.
 - Read-only live integration tests are implemented; destructive live tests are still intentionally gated for a future design.

--- a/.agents/docs/TODO.md
+++ b/.agents/docs/TODO.md
@@ -2,7 +2,7 @@
 
 ## Active Follow-Ups
 
-Follow-up plan: [`plans/client-resilience-and-ergonomics-plan.md`](plans/client-resilience-and-ergonomics-plan.md)
+Follow-up plan: [`plans/client-resilience-and-ergonomics-follow-ups.md`](plans/client-resilience-and-ergonomics-follow-ups.md)
 
 ### Destructive Live Tests
 
@@ -20,7 +20,7 @@ Plan archived: [`archived/dataclass-low-level-models-plan.md`](archived/dataclas
 
 ### Client Resilience and Ergonomics
 
-Archived plan: [`archived/client-resilience-and-ergonomics-plan.md`](archived/client-resilience-and-ergonomics-plan.md)
+Archived plan: [`archived/completed-client-resilience-and-ergonomics-plan.md`](archived/completed-client-resilience-and-ergonomics-plan.md)
 
 - [x] Add WebSocket reconnect, heartbeat configuration, graceful cancellation, and non-blocking handler dispatch.
 - [x] Add conservative REST retry/rate-limit support.

--- a/.agents/docs/archived/client-resilience-and-ergonomics-plan.md
+++ b/.agents/docs/archived/client-resilience-and-ergonomics-plan.md
@@ -1,0 +1,90 @@
+# Client Resilience and Ergonomics Plan
+
+Status: **implemented and archived**.
+
+This plan tracked production-readiness and ergonomics work for the REST v3 client and WebSocket stream. The client-resilience milestone is complete; remaining destructive live-test and dataclass-model ideas are tracked separately in `.agents/docs/plans/client-resilience-and-ergonomics-plan.md` and related archived plans.
+
+## Implemented Scope
+
+### WebSocket Production Resilience
+
+Implemented in `src/maicoin/ws/stream.py`.
+
+- `ReconnectPolicy` controls reconnect behavior, including max retries, base delay, max delay, and jitter.
+- `Stream` can reconnect after non-cancellation disconnects and replay queued auth/subscription requests.
+- Lifecycle callbacks are available for connection events:
+  - `on_connected`
+  - `on_disconnected`
+  - `on_reconnecting`
+  - `on_permanent_failure`
+- `asyncio.CancelledError` is not swallowed, and the websocket is closed cleanly during cancellation.
+- WebSocket connection options such as ping/timeout/queue settings can be passed through to the underlying connection factory.
+- Tests simulate reconnects, disconnects, replayed subscriptions, and cancellation behavior in `tests/ws/test_stream.py`.
+
+### Non-Blocking WebSocket Dispatch
+
+Implemented in `src/maicoin/ws/stream.py`.
+
+- Handlers may be synchronous or asynchronous callables.
+- Dispatch modes are supported:
+  - `inline`: backward-compatible, ordered handler execution.
+  - `task`: schedule handler work with `asyncio.create_task()`.
+  - `queue`: enqueue responses for consumer-managed processing.
+- Handler exceptions are isolated through the configured error-handling path instead of unexpectedly killing normal receive-loop operation.
+- Tests cover async handlers, task dispatch, queue dispatch, and handler error behavior.
+
+### REST Retry and Rate-Limit Policy
+
+Implemented in `src/maicoin/v3/client.py`.
+
+- `RetryPolicy` controls retry attempts, backoff, max delay, jitter, retryable status codes, timeout/network retries, and `Retry-After` handling.
+- Default behavior is conservative:
+  - safe retries apply to idempotent methods such as `GET`.
+  - non-idempotent requests are not retried unless explicitly enabled with `retry_non_idempotent=True`.
+- Existing exception behavior is preserved after retry exhaustion.
+- Tests cover retryable statuses, `Retry-After`, network failures, and non-idempotent retry gating in `tests/v3/test_client.py`.
+
+### Async-First REST Client
+
+Implemented in `src/maicoin/v3/client.py`.
+
+- `Client` is async-first across the REST v3 surface.
+- Public, authenticated read, and authenticated write methods are `async def` methods and use `httpx.AsyncClient` internally by default.
+- `Client` supports async lifecycle management:
+
+```python
+async with Client(api_key="...", api_secret="...") as client:
+    markets = await client.markets()
+    accounts = await client.accounts()
+```
+
+- `await client.aclose()` is available for explicit cleanup.
+- Explicit `_sync` convenience wrappers exist for synchronous scripts and applications.
+- `_sync` wrappers have endpoint-specific signatures and return types for better IDE/type-checker support.
+- `_sync` wrappers raise when called inside an already-running event loop; async applications such as FastAPI, Jupyter, and async bots should await async methods directly.
+- Default sync-wrapper calls use fresh async sessions to avoid cross-event-loop reuse of the underlying `httpx.AsyncClient`.
+- Tests have been converted toward native async style with `pytest.mark.anyio`.
+
+### Pagination Helpers
+
+Implemented in `src/maicoin/v3/client.py`.
+
+- Async iterator helpers are available for historical/list workflows that have clear id/cursor progression semantics, including:
+  - `iter_wallet_trades(...)`
+  - `iter_order_history(...)`
+- Iterators support page limits, `max_items`, and `max_pages` stop conditions.
+- Tests cover cursor advancement, short-page termination, duplicate prevention, and max-page limits in `tests/v3/test_private.py`.
+
+### Documentation and Examples
+
+Implemented in `README.md` and examples.
+
+- REST examples use async-first calls.
+- Synchronous wrapper usage remains documented for simple scripts.
+- Async lifecycle guidance covers `async with Client()`, `await client.aclose()`, and `_sync` wrapper limitations inside running event loops.
+- README includes a FastAPI dependency example.
+
+## Verification
+
+- Client-resilience work landed via PR #62 / commit `1ae3b73 feat: add client resilience controls` and related prior PRs for async pagination, sync-wrapper lifecycle hardening, and sync-wrapper typing.
+- Tests cover WebSocket reconnect/dispatch behavior, REST retries, async client methods, sync-wrapper safeguards, and async pagination iterators.

--- a/.agents/docs/archived/completed-client-resilience-and-ergonomics-plan.md
+++ b/.agents/docs/archived/completed-client-resilience-and-ergonomics-plan.md
@@ -2,7 +2,7 @@
 
 Status: **implemented and archived**.
 
-This plan tracked production-readiness and ergonomics work for the REST v3 client and WebSocket stream. The client-resilience milestone is complete; remaining destructive live-test and dataclass-model ideas are tracked separately in `.agents/docs/plans/client-resilience-and-ergonomics-plan.md` and related archived plans.
+This plan tracked production-readiness and ergonomics work for the REST v3 client and WebSocket stream. The client-resilience milestone is complete; remaining destructive live-test and dataclass-model ideas are tracked separately in `.agents/docs/plans/client-resilience-and-ergonomics-follow-ups.md` and related archived plans.
 
 ## Implemented Scope
 

--- a/.agents/docs/plans/client-resilience-and-ergonomics-follow-ups.md
+++ b/.agents/docs/plans/client-resilience-and-ergonomics-follow-ups.md
@@ -2,7 +2,7 @@
 
 Status: **active follow-ups only**.
 
-The implemented client resilience and ergonomics work has been archived at [`../archived/client-resilience-and-ergonomics-plan.md`](../archived/client-resilience-and-ergonomics-plan.md).
+The implemented client resilience and ergonomics work has been archived at [`../archived/completed-client-resilience-and-ergonomics-plan.md`](../archived/completed-client-resilience-and-ergonomics-plan.md).
 
 There is no remaining core client-resilience implementation work in this plan. The only related follow-ups are intentionally deferred safety/benchmark tasks.
 

--- a/.agents/docs/plans/client-resilience-and-ergonomics-plan.md
+++ b/.agents/docs/plans/client-resilience-and-ergonomics-plan.md
@@ -1,154 +1,32 @@
-# Client Resilience and Ergonomics Plan
+# Client Resilience and Ergonomics Follow-Up Plan
 
-## Review of Reported Gaps
+Status: **active follow-ups only**.
 
-Overall, the review is directionally correct. The current package has broad endpoint coverage, but several production-readiness and ergonomics gaps remain.
+The implemented client resilience and ergonomics work has been archived at [`../archived/client-resilience-and-ergonomics-plan.md`](../archived/client-resilience-and-ergonomics-plan.md).
 
-1. **Async REST client: valid, but not urgent for all users.** `src/maicoin/v3/client.py` is synchronous and uses `httpx.Client`. Async users currently need a thread pool or must call `Client.request()` through their own async wrapper. Because the dependency is already `httpx`, an `AsyncClient` is feasible, but it doubles the public client surface unless the request-building/parsing logic is shared carefully.
-2. **WebSocket reconnect / heartbeat / recovery: valid and high impact.** `Stream.arun()` opens one connection and raises on disconnect. It does not implement reconnect backoff, resubscription after reconnect, explicit ping/heartbeat configuration, graceful cancellation, or error callbacks.
-3. **WebSocket handlers block the receive loop: valid and high impact.** Handlers are called inline with `handler(resp)`. A slow handler delays `ws.recv()` and can cause dropped/late messages. The stream should support async handlers and/or queue-based dispatch.
-4. **Rate-limit / retry support: valid, but should be conservative.** REST errors currently raise immediately after a single request. There is no `Retry-After` support, timeout retry, or backoff for 429/502/503/504. Automatic retries must be opt-in or limited to safe/idempotent methods unless callers explicitly enable retries for private write endpoints.
-5. **Pagination helpers: valid.** Methods such as `closed_orders()`, `wallet_trades()`, `order_history()`, deposits, withdrawals, transfers, and M-Wallet list endpoints expose cursor/timestamp/from_id/limit parameters, but users must write pagination loops themselves.
-6. **Destructive live tests: valid but lower priority.** Read-only live tests exist. Destructive tests still need a separate safety design because they can place/cancel orders or mutate account state.
-7. **Dataclass low-level models: already planned, but should be lower priority.** A plan exists, but benchmark memory showed Pydantic v2 is currently faster than the manual dataclass parsers tested so far. Treat this as an experimental, benchmark-driven optimization, not an urgent performance fix.
+There is no remaining core client-resilience implementation work in this plan. The only related follow-ups are intentionally deferred safety/benchmark tasks.
 
-## Recommended Priority Order
+## Remaining Follow-Ups
 
-### Priority 1: WebSocket Production Resilience
+### Destructive Live Tests
 
-Goal: make `Stream` stable enough for long-running processes.
+Plan reference: [`../archived/live-integration-tests-plan.md`](../archived/live-integration-tests-plan.md)
 
-Planned changes:
+- [ ] Design opt-in destructive live tests with explicit environment gates, balance checks, cleanup, and manual recovery steps.
 
-- Add configurable reconnect policy:
-  - `reconnect: bool = True`
-  - `max_retries: int | None = None`
-  - `base_delay`, `max_delay`, jitter
-- Re-send queued auth/subscription requests after reconnect.
-- Add callbacks or handler events for connection lifecycle:
-  - connected
-  - disconnected
-  - reconnecting
-  - permanent failure
-- Support graceful cancellation:
-  - do not swallow `asyncio.CancelledError`
-  - close websocket cleanly on cancellation
-- Expose `websockets.connect()` options such as `ping_interval`, `ping_timeout`, `close_timeout`, and maybe `max_queue`.
-- Add unit tests with a fake websocket/connect factory that simulates disconnects and verifies resubscription/backoff behavior.
+Notes:
 
-### Priority 2: Non-Blocking WebSocket Dispatch
+- Read-only live tests already exist.
+- Mutating tests that place/cancel orders or otherwise change account state require a separate safety design.
+- Future destructive tests must not run in normal CI.
 
-Goal: avoid blocking the receive loop when handlers are slow.
+### Dataclass Low-Level Models
 
-Planned changes:
+Plan reference: [`../archived/dataclass-low-level-models-plan.md`](../archived/dataclass-low-level-models-plan.md)
 
-- Type handlers as sync or async callables accepting `Response`.
-- Detect awaitables and support `async def` handlers.
-- Add dispatch modes:
-  - `inline`: current behavior, backwards compatible
-  - `task`: schedule each handler with `asyncio.create_task()`
-  - `queue`: push responses to an `asyncio.Queue` for consumer-managed processing
-- Add error handling for handler exceptions so one bad handler does not kill the stream unless configured.
-- Document ordering trade-offs: inline preserves strict order; task mode may not; queue mode gives user control.
+- [ ] Revisit low-level dataclass models only if fresh benchmark evidence shows value and there is a compatibility migration path.
 
-### Priority 3: REST Retry and Rate-Limit Policy
+Notes:
 
-Goal: reduce transient failures without hiding important API errors.
-
-Planned changes:
-
-- Add a small `RetryPolicy` dataclass:
-  - enabled
-  - total attempts
-  - backoff factor / max delay / jitter
-  - retry status codes: default `429, 502, 503, 504`
-  - retry timeout/network exceptions
-  - respect `Retry-After` when present
-- Default to conservative behavior:
-  - safe retries for `GET`
-  - no automatic retry for private write methods unless explicitly enabled
-- Preserve current exceptions after retry exhaustion.
-- Add tests for 429 with `Retry-After`, 503 backoff, timeout retry, and no retry on non-idempotent POST by default.
-
-### Priority 4: Pagination Helpers
-
-Goal: make common historical data access easier and less error-prone.
-
-Planned changes:
-
-- Add iterator helpers such as:
-  - `iter_wallet_trades(...)`
-  - `iter_closed_orders(...)`
-  - `iter_order_history(...)`
-  - `iter_deposits(...)`
-  - `iter_withdrawals(...)`
-  - `iter_m_wallet_*` for list endpoints with compatible pagination fields
-- Keep existing list-returning methods unchanged.
-- Start with endpoints that use `from_id` or timestamp/order semantics clearly documented by MAX.
-- Stop conditions:
-  - empty page
-  - page smaller than limit
-  - caller-provided `max_items` / `max_pages`
-- Add tests for parameter progression and duplicate prevention.
-
-### Priority 5: Async-First REST Client
-
-Goal: support FastAPI, asyncio bots, and async services natively while keeping a simple sync convenience layer.
-
-Preferred design:
-
-- Make `Client` async-first instead of adding a separate `AsyncClient` class.
-- Convert the whole typed REST surface to async methods, not just selected endpoints. Examples:
-
-```python
-async with Client(api_key="...", api_secret="...") as client:
-    markets = await client.markets()
-    currencies = await client.currencies()
-    ticker = await client.ticker("btctwd")
-    accounts = await client.accounts()
-```
-
-- Apply the same async-first rule to public endpoints, authenticated read endpoints, and authenticated write endpoints such as order creation/cancellation.
-- Use `httpx.AsyncClient` and an async session protocol internally.
-- Add sync convenience wrappers with an explicit `_sync` suffix for the whole REST surface:
-
-```python
-def currencies_sync(self) -> list[Currency]:
-    return asyncio.run(self.currencies())
-```
-
-- For every async method that should remain callable from synchronous scripts, provide the matching `_sync` wrapper, for example `markets_sync()`, `ticker_sync(...)`, `accounts_sync()`, and `create_order_sync(...)`.
-- Treat `_sync` wrappers as convenience APIs for scripts and synchronous applications, not for code already running inside an event loop. Document that `asyncio.run()` raises when called from an existing event loop, so FastAPI/Jupyter/async bot users should call the async methods directly.
-- Preserve request construction, auth signing, nonce injection, error handling, and model parsing behavior while changing the transport to async.
-- Because this changes existing `Client` method call semantics from `client.currencies()` to `await client.currencies()`, plan it as a breaking API change or provide a migration window with deprecation warnings if backwards compatibility is required.
-- Add tests using a fake async session, tests for `_sync` wrappers, and type checks for async public methods.
-
-### Priority 6: Destructive Live Tests
-
-Goal: safely test order placement/cancellation and other mutating endpoints.
-
-Planned changes:
-
-- Keep destructive tests opt-in behind a separate environment flag such as `RUN_DESTRUCTIVE_LIVE_TESTS=1`.
-- Require explicit market/currency env vars and minimum balance checks.
-- Use far-from-market limit orders where possible.
-- Always attempt cleanup and document manual recovery steps.
-- Do not run destructive tests in normal CI.
-
-### Priority 7: Dataclass Low-Level Models
-
-Goal: only continue if benchmark evidence shows value or if users need a low-level payload-shaped API.
-
-Planned changes:
-
-- Keep the existing dataclass plan in `.agents/docs/plans/dataclass-low-level-models-plan.md`.
-- Re-run benchmarks before implementation.
-- Preserve transport-specific raw models and normalized domain models as separate layers.
-- Avoid replacing Pydantic unless there is a measured benefit and a compatibility migration path.
-
-## Acceptance Criteria
-
-- Existing public API remains backwards compatible except for explicitly planned breaking changes such as an async-first REST client migration.
-- New behavior is opt-in where it could surprise users, or documented as part of a deliberate migration path.
-- Unit tests cover failure paths, cancellation, retries, and pagination edge cases.
-- Documentation explains when to use async REST methods, `_sync` REST wrappers, inline WebSocket handlers, task dispatch, and queue dispatch.
+- The previous benchmark showed Pydantic v2 was faster than the tested manual dataclass parser.
+- Do not replace Pydantic models without new benchmark evidence.


### PR DESCRIPTION
## Summary
- archive the completed client resilience and ergonomics plan
- keep only active follow-up items in the plans directory
- clarify TODO completed milestones and remaining unchecked follow-ups

## Tests
- Not run (documentation-only change)