### PR TITLE
refactor(v3): split REST endpoint modules

### DIFF
--- a/src/maicoin/v3/_endpoints/__init__.py
+++ b/src/maicoin/v3/_endpoints/__init__.py
@@ -1,0 +1,15 @@
+"""Internal REST v3 endpoint families."""
+
+from maicoin.v3._endpoints.convert import ConvertEndpoints
+from maicoin.v3._endpoints.funds import FundsEndpoints
+from maicoin.v3._endpoints.m_wallet import MWalletEndpoints
+from maicoin.v3._endpoints.order_intake_history import OrderIntakeHistoryEndpoints
+from maicoin.v3._endpoints.public_market_data import PublicMarketDataEndpoints
+
+__all__ = [
+    "ConvertEndpoints",
+    "FundsEndpoints",
+    "MWalletEndpoints",
+    "OrderIntakeHistoryEndpoints",
+    "PublicMarketDataEndpoints",
+]

--- a/src/maicoin/v3/_endpoints/base.py
+++ b/src/maicoin/v3/_endpoints/base.py
@@ -1,0 +1,155 @@
+"""Shared internals for REST v3 endpoint families."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from collections.abc import Awaitable
+from collections.abc import Callable
+from collections.abc import Mapping
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+from typing import TypeVar
+from typing import cast
+
+from pydantic import BaseModel
+
+
+class RestRequester(Protocol):
+    """Minimal seam endpoint families need from the public client."""
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        params: Mapping[str, object] | None = None,
+        *,
+        auth: bool = False,
+    ) -> object: ...
+
+
+ModelT = TypeVar("ModelT", bound=BaseModel)
+
+
+@dataclass(frozen=True, slots=True)
+class EndpointSpec:
+    """Static MAX REST v3 request metadata for one endpoint."""
+
+    method: str
+    path: str
+    auth: bool = False
+
+    def resolved_path(self, path_params: Mapping[str, object] | None = None) -> str:
+        """Format a path template using endpoint-family path params."""
+        if not path_params:
+            return self.path
+        return self.path.format(**path_params)
+
+
+@dataclass(frozen=True, slots=True)
+class EndpointExecutor:
+    """Execute endpoint specs and centralize common response parsing shapes."""
+
+    requester: RestRequester
+
+    async def raw(
+        self,
+        spec: EndpointSpec,
+        params: Mapping[str, object | None] | None = None,
+        *,
+        path_params: Mapping[str, object] | None = None,
+    ) -> object:
+        """Execute an endpoint spec with consistent param omission and auth metadata."""
+        return await self.requester.request(
+            spec.method,
+            spec.resolved_path(path_params),
+            params=compact(params or {}),
+            auth=spec.auth,
+        )
+
+    async def model(
+        self,
+        spec: EndpointSpec,
+        model: type[ModelT],
+        params: Mapping[str, object | None] | None = None,
+        *,
+        path_params: Mapping[str, object] | None = None,
+    ) -> ModelT:
+        """Execute an endpoint and parse a single Pydantic model."""
+        payload = await self.raw(spec, params=params, path_params=path_params)
+        return model.model_validate(payload)
+
+    async def model_list(
+        self,
+        spec: EndpointSpec,
+        model: type[ModelT],
+        params: Mapping[str, object | None] | None = None,
+        *,
+        path_params: Mapping[str, object] | None = None,
+    ) -> list[ModelT]:
+        """Execute an endpoint and parse a JSON array of Pydantic models."""
+        payload = await self.raw(spec, params=params, path_params=path_params)
+        return [model.model_validate(item) for item in cast("list[object]", payload)]
+
+    async def model_mapping(
+        self,
+        spec: EndpointSpec,
+        model: type[ModelT],
+        params: Mapping[str, object | None] | None = None,
+        *,
+        path_params: Mapping[str, object] | None = None,
+    ) -> dict[str, ModelT]:
+        """Execute an endpoint and parse a JSON object keyed to Pydantic models."""
+        payload = await self.raw(spec, params=params, path_params=path_params)
+        return {key: model.model_validate(value) for key, value in cast("dict[str, object]", payload).items()}
+
+
+def compact(params: Mapping[str, object | None]) -> dict[str, object]:
+    """Drop None-valued request params while keeping false-y API values."""
+    return {key: value for key, value in params.items() if value is not None}
+
+
+async def iter_id_paginated[PageItemT](  # noqa: C901
+    fetch_page: Callable[[int | None, int], Awaitable[Sequence[PageItemT]]],
+    item_id: Callable[[PageItemT], int],
+    *,
+    from_id: int | None,
+    page_limit: int,
+    max_items: int | None,
+    max_pages: int | None,
+) -> AsyncIterator[PageItemT]:
+    """Iterate MAX id-cursor pages while avoiding cursor-boundary duplicates."""
+    if page_limit <= 0:
+        msg = "page_limit must be greater than 0"
+        raise ValueError(msg)
+    if max_items == 0 or max_pages == 0:
+        return
+
+    cursor = from_id
+    yielded = 0
+    seen_ids: set[int] = set()
+    page_count = max_pages if max_pages is not None else 2**63
+
+    for page_number in range(page_count):
+        page = await fetch_page(cursor, page_limit)
+        if not page:
+            return
+
+        next_cursor = cursor
+        for item in page:
+            current_id = item_id(item)
+            if current_id in seen_ids:
+                continue
+            seen_ids.add(current_id)
+            yield item
+            yielded += 1
+            if max_items is not None and yielded >= max_items:
+                return
+            if next_cursor is None or current_id > next_cursor:
+                next_cursor = current_id
+
+        if len(page) < page_limit or page_number + 1 >= page_count:
+            return
+        if next_cursor == cursor:
+            return
+        cursor = next_cursor

--- a/src/maicoin/v3/_endpoints/convert.py
+++ b/src/maicoin/v3/_endpoints/convert.py
@@ -1,0 +1,56 @@
+"""Convert REST v3 endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from maicoin.v3._endpoints.base import EndpointExecutor
+from maicoin.v3._endpoints.base import EndpointSpec
+from maicoin.v3._endpoints.base import RestRequester
+from maicoin.v3.models import ConvertOrder
+
+CREATE_CONVERT = EndpointSpec("POST", "/api/v3/convert", auth=True)
+CONVERT = EndpointSpec("GET", "/api/v3/convert", auth=True)
+CONVERTS = EndpointSpec("GET", "/api/v3/converts", auth=True)
+
+
+@dataclass(frozen=True, slots=True)
+class ConvertEndpoints:
+    """Authenticated convert request/parse rules."""
+
+    requester: RestRequester
+
+    @property
+    def endpoint(self) -> EndpointExecutor:
+        return EndpointExecutor(self.requester)
+
+    async def create_convert(
+        self,
+        *,
+        from_currency: str,
+        to_currency: str,
+        from_amount: str | None = None,
+        to_amount: str | None = None,
+    ) -> ConvertOrder:
+        return await self.endpoint.model(
+            CREATE_CONVERT,
+            ConvertOrder,
+            {
+                "from_currency": from_currency,
+                "to_currency": to_currency,
+                "from_amount": from_amount,
+                "to_amount": to_amount,
+            },
+        )
+
+    async def convert(self, sn: str) -> ConvertOrder:
+        return await self.endpoint.model(CONVERT, ConvertOrder, {"sn": sn})
+
+    async def converts(
+        self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
+    ) -> list[ConvertOrder]:
+        return await self.endpoint.model_list(
+            CONVERTS,
+            ConvertOrder,
+            {"timestamp": timestamp, "order": order, "limit": limit},
+        )

--- a/src/maicoin/v3/_endpoints/funds.py
+++ b/src/maicoin/v3/_endpoints/funds.py
@@ -1,0 +1,179 @@
+"""Funds, deposits, withdrawals, and settlement REST v3 endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from maicoin.v3._endpoints.base import EndpointExecutor
+from maicoin.v3._endpoints.base import EndpointSpec
+from maicoin.v3._endpoints.base import RestRequester
+from maicoin.v3.models import Deposit
+from maicoin.v3.models import DepositAddress
+from maicoin.v3.models import FundTransactionDeposit
+from maicoin.v3.models import FundTransactionTransfer
+from maicoin.v3.models import FundTransactionWithdrawal
+from maicoin.v3.models import InternalTransfer
+from maicoin.v3.models import Reward
+from maicoin.v3.models import WithdrawAddress
+from maicoin.v3.models import Withdrawal
+
+WITHDRAWAL = EndpointSpec("GET", "/api/v3/withdrawal", auth=True)
+CREATE_WITHDRAWAL = EndpointSpec("POST", "/api/v3/withdrawal", auth=True)
+CREATE_TWD_WITHDRAWAL = EndpointSpec("POST", "/api/v3/withdrawal/twd", auth=True)
+WITHDRAWALS = EndpointSpec("GET", "/api/v3/withdrawals", auth=True)
+WITHDRAW_ADDRESSES = EndpointSpec("GET", "/api/v3/withdraw_addresses", auth=True)
+DEPOSIT = EndpointSpec("GET", "/api/v3/deposit", auth=True)
+DEPOSITS = EndpointSpec("GET", "/api/v3/deposits", auth=True)
+DEPOSIT_ADDRESS = EndpointSpec("GET", "/api/v3/deposit_address", auth=True)
+INTERNAL_TRANSFERS = EndpointSpec("GET", "/api/v3/internal_transfers", auth=True)
+REWARDS = EndpointSpec("GET", "/api/v3/rewards", auth=True)
+FUND_TRANSACTION_DEPOSITS = EndpointSpec("GET", "/api/v3/fund_transactions/deposits", auth=True)
+FUND_TRANSACTION_DEPOSIT = EndpointSpec("GET", "/api/v3/fund_transactions/deposit", auth=True)
+FUND_TRANSACTION_WITHDRAWALS = EndpointSpec("GET", "/api/v3/fund_transactions/withdrawals", auth=True)
+FUND_TRANSACTION_WITHDRAWAL = EndpointSpec("GET", "/api/v3/fund_transactions/withdrawal", auth=True)
+FUND_TRANSACTION_TRANSFERS = EndpointSpec("GET", "/api/v3/fund_transactions/transfers", auth=True)
+FUND_TRANSACTION_TRANSFER = EndpointSpec("GET", "/api/v3/fund_transactions/transfer", auth=True)
+
+
+@dataclass(frozen=True, slots=True)
+class FundsEndpoints:
+    """Authenticated fund movement request/parse rules."""
+
+    requester: RestRequester
+
+    @property
+    def endpoint(self) -> EndpointExecutor:
+        return EndpointExecutor(self.requester)
+
+    async def withdrawal(self, uuid: str) -> Withdrawal:
+        return await self.endpoint.model(WITHDRAWAL, Withdrawal, {"uuid": uuid})
+
+    async def create_withdrawal(self, *, withdraw_address_uuid: str, amount: str) -> Withdrawal:
+        return await self.endpoint.model(
+            CREATE_WITHDRAWAL,
+            Withdrawal,
+            {"withdraw_address_uuid": withdraw_address_uuid, "amount": amount},
+        )
+
+    async def create_twd_withdrawal(self, amount: str) -> Withdrawal:
+        return await self.endpoint.model(CREATE_TWD_WITHDRAWAL, Withdrawal, {"amount": amount})
+
+    async def withdrawals(
+        self,
+        *,
+        currency: str | None = None,
+        state: str | None = None,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[Withdrawal]:
+        return await self.endpoint.model_list(
+            WITHDRAWALS,
+            Withdrawal,
+            {"currency": currency, "state": state, "timestamp": timestamp, "order": order, "limit": limit},
+        )
+
+    async def withdraw_addresses(
+        self,
+        currency: str,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[WithdrawAddress]:
+        return await self.endpoint.model_list(
+            WITHDRAW_ADDRESSES,
+            WithdrawAddress,
+            {"currency": currency, "limit": limit, "offset": offset},
+        )
+
+    async def deposit(self, *, txid: str | None = None, uuid: str | None = None) -> Deposit:
+        return await self.endpoint.model(DEPOSIT, Deposit, {"txid": txid, "uuid": uuid})
+
+    async def deposits(
+        self,
+        *,
+        currency: str | None = None,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[Deposit]:
+        return await self.endpoint.model_list(
+            DEPOSITS,
+            Deposit,
+            {"currency": currency, "timestamp": timestamp, "order": order, "limit": limit},
+        )
+
+    async def deposit_address(self, currency_version: str) -> DepositAddress:
+        return await self.endpoint.model(DEPOSIT_ADDRESS, DepositAddress, {"currency_version": currency_version})
+
+    async def internal_transfers(
+        self,
+        side: str,
+        *,
+        currency: str | None = None,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[InternalTransfer]:
+        return await self.endpoint.model_list(
+            INTERNAL_TRANSFERS,
+            InternalTransfer,
+            {"side": side, "currency": currency, "timestamp": timestamp, "order": order, "limit": limit},
+        )
+
+    async def rewards(
+        self,
+        *,
+        reward_type: str | None = None,
+        currency: str | None = None,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[Reward]:
+        return await self.endpoint.model_list(
+            REWARDS,
+            Reward,
+            {
+                "reward_type": reward_type,
+                "currency": currency,
+                "timestamp": timestamp,
+                "order": order,
+                "limit": limit,
+            },
+        )
+
+    async def fund_transaction_deposits(
+        self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
+    ) -> list[FundTransactionDeposit]:
+        return await self.endpoint.model_list(
+            FUND_TRANSACTION_DEPOSITS,
+            FundTransactionDeposit,
+            {"timestamp": timestamp, "order": order, "limit": limit},
+        )
+
+    async def fund_transaction_deposit(self, sn: str) -> FundTransactionDeposit:
+        return await self.endpoint.model(FUND_TRANSACTION_DEPOSIT, FundTransactionDeposit, {"sn": sn})
+
+    async def fund_transaction_withdrawals(
+        self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
+    ) -> list[FundTransactionWithdrawal]:
+        return await self.endpoint.model_list(
+            FUND_TRANSACTION_WITHDRAWALS,
+            FundTransactionWithdrawal,
+            {"timestamp": timestamp, "order": order, "limit": limit},
+        )
+
+    async def fund_transaction_withdrawal(self, sn: str) -> FundTransactionWithdrawal:
+        return await self.endpoint.model(FUND_TRANSACTION_WITHDRAWAL, FundTransactionWithdrawal, {"sn": sn})
+
+    async def fund_transaction_transfers(
+        self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
+    ) -> list[FundTransactionTransfer]:
+        return await self.endpoint.model_list(
+            FUND_TRANSACTION_TRANSFERS,
+            FundTransactionTransfer,
+            {"timestamp": timestamp, "order": order, "limit": limit},
+        )
+
+    async def fund_transaction_transfer(self, sn: str) -> FundTransactionTransfer:
+        return await self.endpoint.model(FUND_TRANSACTION_TRANSFER, FundTransactionTransfer, {"sn": sn})

--- a/src/maicoin/v3/_endpoints/m_wallet.py
+++ b/src/maicoin/v3/_endpoints/m_wallet.py
@@ -1,0 +1,158 @@
+"""M-Wallet REST v3 endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+from maicoin.v3._endpoints.base import EndpointExecutor
+from maicoin.v3._endpoints.base import EndpointSpec
+from maicoin.v3._endpoints.base import RestRequester
+from maicoin.v3.models import HistoricalIndexPrice
+from maicoin.v3.models import InterestRate
+from maicoin.v3.models import MWalletADRatio
+from maicoin.v3.models import MWalletInterest
+from maicoin.v3.models import MWalletLiquidation
+from maicoin.v3.models import MWalletLiquidationDetail
+from maicoin.v3.models import MWalletLoan
+from maicoin.v3.models import MWalletRepayment
+from maicoin.v3.models import MWalletTransfer
+
+M_WALLET_INDEX_PRICES = EndpointSpec("GET", "/api/v3/wallet/m/index_prices")
+M_WALLET_HISTORICAL_INDEX_PRICES = EndpointSpec("GET", "/api/v3/wallet/m/historical_index_prices")
+M_WALLET_LIMITS = EndpointSpec("GET", "/api/v3/wallet/m/limits")
+M_WALLET_INTEREST_RATES = EndpointSpec("GET", "/api/v3/wallet/m/interest_rates")
+CREATE_M_WALLET_LOAN = EndpointSpec("POST", "/api/v3/wallet/m/loan", auth=True)
+M_WALLET_LOANS = EndpointSpec("GET", "/api/v3/wallet/m/loans", auth=True)
+CREATE_M_WALLET_TRANSFER = EndpointSpec("POST", "/api/v3/wallet/m/transfer", auth=True)
+M_WALLET_TRANSFERS = EndpointSpec("GET", "/api/v3/wallet/m/transfers", auth=True)
+CREATE_M_WALLET_REPAYMENT = EndpointSpec("POST", "/api/v3/wallet/m/repayment", auth=True)
+M_WALLET_REPAYMENTS = EndpointSpec("GET", "/api/v3/wallet/m/repayments", auth=True)
+M_WALLET_LIQUIDATIONS = EndpointSpec("GET", "/api/v3/wallet/m/liquidations", auth=True)
+M_WALLET_LIQUIDATION = EndpointSpec("GET", "/api/v3/wallet/m/liquidation", auth=True)
+M_WALLET_INTERESTS = EndpointSpec("GET", "/api/v3/wallet/m/interests", auth=True)
+M_WALLET_AD_RATIO = EndpointSpec("GET", "/api/v3/wallet/m/ad_ratio", auth=True)
+
+
+@dataclass(frozen=True, slots=True)
+class MWalletEndpoints:
+    """M-Wallet public and authenticated request/parse rules."""
+
+    requester: RestRequester
+
+    @property
+    def endpoint(self) -> EndpointExecutor:
+        return EndpointExecutor(self.requester)
+
+    async def m_wallet_index_prices(self) -> dict[str, str]:
+        payload = await self.endpoint.raw(M_WALLET_INDEX_PRICES)
+        return cast("dict[str, str]", payload)
+
+    async def m_wallet_historical_index_prices(
+        self,
+        market: str,
+        *,
+        start_time: int,
+        end_time: int,
+    ) -> list[HistoricalIndexPrice]:
+        return await self.endpoint.model_list(
+            M_WALLET_HISTORICAL_INDEX_PRICES,
+            HistoricalIndexPrice,
+            {"market": market, "start_time": start_time, "end_time": end_time},
+        )
+
+    async def m_wallet_limits(self) -> dict[str, str]:
+        payload = await self.endpoint.raw(M_WALLET_LIMITS)
+        return cast("dict[str, str]", payload)
+
+    async def m_wallet_interest_rates(self) -> dict[str, InterestRate]:
+        return await self.endpoint.model_mapping(M_WALLET_INTEREST_RATES, InterestRate)
+
+    async def create_m_wallet_loan(self, *, currency: str, amount: str) -> MWalletLoan:
+        return await self.endpoint.model(CREATE_M_WALLET_LOAN, MWalletLoan, {"currency": currency, "amount": amount})
+
+    async def m_wallet_loans(
+        self,
+        currency: str,
+        *,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[MWalletLoan]:
+        return await self.endpoint.model_list(
+            M_WALLET_LOANS,
+            MWalletLoan,
+            {"currency": currency, "timestamp": timestamp, "order": order, "limit": limit},
+        )
+
+    async def create_m_wallet_transfer(self, *, currency: str, amount: str, side: str) -> MWalletTransfer:
+        return await self.endpoint.model(
+            CREATE_M_WALLET_TRANSFER,
+            MWalletTransfer,
+            {"currency": currency, "amount": amount, "side": side},
+        )
+
+    async def m_wallet_transfers(
+        self,
+        *,
+        currency: str,
+        side: str,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[MWalletTransfer]:
+        return await self.endpoint.model_list(
+            M_WALLET_TRANSFERS,
+            MWalletTransfer,
+            {"currency": currency, "side": side, "timestamp": timestamp, "order": order, "limit": limit},
+        )
+
+    async def create_m_wallet_repayment(self, *, currency: str, amount: str) -> MWalletRepayment:
+        return await self.endpoint.model(
+            CREATE_M_WALLET_REPAYMENT,
+            MWalletRepayment,
+            {"currency": currency, "amount": amount},
+        )
+
+    async def m_wallet_repayments(
+        self,
+        currency: str,
+        *,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[MWalletRepayment]:
+        return await self.endpoint.model_list(
+            M_WALLET_REPAYMENTS,
+            MWalletRepayment,
+            {"currency": currency, "timestamp": timestamp, "order": order, "limit": limit},
+        )
+
+    async def m_wallet_liquidations(
+        self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
+    ) -> list[MWalletLiquidation]:
+        return await self.endpoint.model_list(
+            M_WALLET_LIQUIDATIONS,
+            MWalletLiquidation,
+            {"timestamp": timestamp, "order": order, "limit": limit},
+        )
+
+    async def m_wallet_liquidation(self, sn: str) -> MWalletLiquidationDetail:
+        return await self.endpoint.model(M_WALLET_LIQUIDATION, MWalletLiquidationDetail, {"sn": sn})
+
+    async def m_wallet_interests(
+        self,
+        *,
+        currency: str | None = None,
+        timestamp: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[MWalletInterest]:
+        return await self.endpoint.model_list(
+            M_WALLET_INTERESTS,
+            MWalletInterest,
+            {"currency": currency, "timestamp": timestamp, "order": order, "limit": limit},
+        )
+
+    async def m_wallet_ad_ratio(self) -> MWalletADRatio:
+        return await self.endpoint.model(M_WALLET_AD_RATIO, MWalletADRatio)

--- a/src/maicoin/v3/_endpoints/order_intake_history.py
+++ b/src/maicoin/v3/_endpoints/order_intake_history.py
@@ -1,0 +1,228 @@
+"""Order intake, order history, account, and private-trade REST v3 endpoints."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from maicoin.v3._endpoints.base import EndpointExecutor
+from maicoin.v3._endpoints.base import EndpointSpec
+from maicoin.v3._endpoints.base import RestRequester
+from maicoin.v3._endpoints.base import iter_id_paginated
+from maicoin.v3.models import Account
+from maicoin.v3.models import Order
+from maicoin.v3.models import OrderSide
+from maicoin.v3.models import OrderType
+from maicoin.v3.models import PrivateTrade
+from maicoin.v3.models import UserInfo
+
+INFO = EndpointSpec("GET", "/api/v3/info", auth=True)
+ACCOUNTS = EndpointSpec("GET", "/api/v3/wallet/{wallet_type}/accounts", auth=True)
+WALLET_TRADES = EndpointSpec("GET", "/api/v3/wallet/{wallet_type}/trades", auth=True)
+OPEN_ORDERS = EndpointSpec("GET", "/api/v3/wallet/{wallet_type}/orders/open", auth=True)
+CLOSED_ORDERS = EndpointSpec("GET", "/api/v3/wallet/{wallet_type}/orders/closed", auth=True)
+ORDER_HISTORY = EndpointSpec("GET", "/api/v3/wallet/{wallet_type}/orders/history", auth=True)
+ORDER = EndpointSpec("GET", "/api/v3/order", auth=True)
+CREATE_ORDER = EndpointSpec("POST", "/api/v3/wallet/{wallet_type}/order", auth=True)
+CANCEL_ORDER = EndpointSpec("DELETE", "/api/v3/order", auth=True)
+CANCEL_ORDERS = EndpointSpec("DELETE", "/api/v3/wallet/{wallet_type}/orders", auth=True)
+ORDER_TRADES = EndpointSpec("GET", "/api/v3/order/trades", auth=True)
+
+
+@dataclass(frozen=True, slots=True)
+class OrderIntakeHistoryEndpoints:
+    """Authenticated account, trade, and order request/parse rules."""
+
+    requester: RestRequester
+
+    @property
+    def endpoint(self) -> EndpointExecutor:
+        return EndpointExecutor(self.requester)
+
+    async def info(self) -> UserInfo:
+        return await self.endpoint.model(INFO, UserInfo)
+
+    async def accounts(self, *, wallet_type: str = "spot", currency: str | None = None) -> list[Account]:
+        return await self.endpoint.model_list(
+            ACCOUNTS,
+            Account,
+            {"currency": currency},
+            path_params={"wallet_type": wallet_type},
+        )
+
+    async def wallet_trades(
+        self,
+        *,
+        wallet_type: str = "spot",
+        market: str | None = None,
+        timestamp: int | None = None,
+        from_id: int | None = None,
+        order: str | None = None,
+        limit: int | None = None,
+    ) -> list[PrivateTrade]:
+        return await self.endpoint.model_list(
+            WALLET_TRADES,
+            PrivateTrade,
+            {"market": market, "timestamp": timestamp, "from_id": from_id, "order": order, "limit": limit},
+            path_params={"wallet_type": wallet_type},
+        )
+
+    async def open_orders(
+        self,
+        *,
+        wallet_type: str = "spot",
+        market: str | None = None,
+        timestamp: int | None = None,
+        order_by: str | None = None,
+        limit: int | None = None,
+    ) -> list[Order]:
+        return await self.endpoint.model_list(
+            OPEN_ORDERS,
+            Order,
+            {"market": market, "timestamp": timestamp, "order_by": order_by, "limit": limit},
+            path_params={"wallet_type": wallet_type},
+        )
+
+    async def closed_orders(
+        self,
+        *,
+        wallet_type: str = "spot",
+        market: str | None = None,
+        timestamp: int | None = None,
+        order_by: str | None = None,
+        limit: int | None = None,
+    ) -> list[Order]:
+        return await self.endpoint.model_list(
+            CLOSED_ORDERS,
+            Order,
+            {"market": market, "timestamp": timestamp, "order_by": order_by, "limit": limit},
+            path_params={"wallet_type": wallet_type},
+        )
+
+    async def order_history(
+        self,
+        market: str,
+        *,
+        wallet_type: str = "spot",
+        from_id: int | None = None,
+        limit: int | None = None,
+    ) -> list[Order]:
+        return await self.endpoint.model_list(
+            ORDER_HISTORY,
+            Order,
+            {"market": market, "from_id": from_id, "limit": limit},
+            path_params={"wallet_type": wallet_type},
+        )
+
+    async def iter_wallet_trades(
+        self,
+        *,
+        wallet_type: str = "spot",
+        market: str | None = None,
+        timestamp: int | None = None,
+        from_id: int | None = None,
+        order: str = "asc",
+        page_limit: int = 100,
+        max_items: int | None = None,
+        max_pages: int | None = None,
+    ) -> AsyncIterator[PrivateTrade]:
+        async def fetch_page(cursor: int | None, limit: int) -> Sequence[PrivateTrade]:
+            return await self.wallet_trades(
+                wallet_type=wallet_type,
+                market=market,
+                timestamp=timestamp,
+                from_id=cursor,
+                order=order,
+                limit=limit,
+            )
+
+        async for trade in iter_id_paginated(
+            fetch_page,
+            lambda trade: trade.id,
+            from_id=from_id,
+            page_limit=page_limit,
+            max_items=max_items,
+            max_pages=max_pages,
+        ):
+            yield trade
+
+    async def iter_order_history(
+        self,
+        market: str,
+        *,
+        wallet_type: str = "spot",
+        from_id: int | None = None,
+        page_limit: int = 100,
+        max_items: int | None = None,
+        max_pages: int | None = None,
+    ) -> AsyncIterator[Order]:
+        async def fetch_page(cursor: int | None, limit: int) -> Sequence[Order]:
+            return await self.order_history(market, wallet_type=wallet_type, from_id=cursor, limit=limit)
+
+        async for order_item in iter_id_paginated(
+            fetch_page,
+            lambda order_item: order_item.id,
+            from_id=from_id,
+            page_limit=page_limit,
+            max_items=max_items,
+            max_pages=max_pages,
+        ):
+            yield order_item
+
+    async def order(self, *, order_id: int | None = None, client_oid: str | None = None) -> Order:
+        return await self.endpoint.model(ORDER, Order, {"id": order_id, "client_oid": client_oid})
+
+    async def create_order(
+        self,
+        market: str,
+        side: OrderSide | str,
+        volume: str,
+        *,
+        wallet_type: str = "spot",
+        price: str | None = None,
+        client_oid: str | None = None,
+        stop_price: str | None = None,
+        ord_type: OrderType | str | None = None,
+        group_id: int | None = None,
+    ) -> Order:
+        return await self.endpoint.model(
+            CREATE_ORDER,
+            Order,
+            {
+                "market": market,
+                "side": side,
+                "volume": volume,
+                "price": price,
+                "client_oid": client_oid,
+                "stop_price": stop_price,
+                "ord_type": ord_type,
+                "group_id": group_id,
+            },
+            path_params={"wallet_type": wallet_type},
+        )
+
+    async def cancel_order(self, *, order_id: int | None = None, client_oid: str | None = None) -> Order:
+        return await self.endpoint.model(CANCEL_ORDER, Order, {"id": order_id, "client_oid": client_oid})
+
+    async def cancel_orders(
+        self,
+        *,
+        wallet_type: str = "spot",
+        market: str | None = None,
+        side: OrderSide | str | None = None,
+        group_id: int | None = None,
+    ) -> list[Order]:
+        return await self.endpoint.model_list(
+            CANCEL_ORDERS,
+            Order,
+            {"market": market, "side": side, "group_id": group_id},
+            path_params={"wallet_type": wallet_type},
+        )
+
+    async def order_trades(self, *, order_id: int | None = None, client_oid: str | None = None) -> list[PrivateTrade]:
+        return await self.endpoint.model_list(
+            ORDER_TRADES,
+            PrivateTrade,
+            {"order_id": order_id, "client_oid": client_oid},
+        )

--- a/src/maicoin/v3/_endpoints/public_market_data.py
+++ b/src/maicoin/v3/_endpoints/public_market_data.py
@@ -1,0 +1,91 @@
+"""Public market-data REST v3 endpoints."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import cast
+
+from maicoin.v3._endpoints.base import EndpointExecutor
+from maicoin.v3._endpoints.base import EndpointSpec
+from maicoin.v3._endpoints.base import RestRequester
+from maicoin.v3.models import Currency
+from maicoin.v3.models import Depth
+from maicoin.v3.models import KLine
+from maicoin.v3.models import Market
+from maicoin.v3.models import PublicTrade
+from maicoin.v3.models import Ticker
+from maicoin.v3.models import Timestamp
+
+MARKETS = EndpointSpec("GET", "/api/v3/markets")
+CURRENCIES = EndpointSpec("GET", "/api/v3/currencies")
+TIMESTAMP = EndpointSpec("GET", "/api/v3/timestamp")
+KLINE = EndpointSpec("GET", "/api/v3/k")
+DEPTH = EndpointSpec("GET", "/api/v3/depth")
+TRADES = EndpointSpec("GET", "/api/v3/trades")
+TICKERS = EndpointSpec("GET", "/api/v3/tickers")
+TICKER = EndpointSpec("GET", "/api/v3/ticker")
+
+
+@dataclass(frozen=True, slots=True)
+class PublicMarketDataEndpoints:
+    """Public MAX market-data request and parsing rules."""
+
+    requester: RestRequester
+
+    @property
+    def endpoint(self) -> EndpointExecutor:
+        return EndpointExecutor(self.requester)
+
+    async def markets(self) -> list[Market]:
+        return await self.endpoint.model_list(MARKETS, Market)
+
+    async def currencies(self) -> list[Currency]:
+        return await self.endpoint.model_list(CURRENCIES, Currency)
+
+    async def timestamp(self) -> Timestamp:
+        return await self.endpoint.model(TIMESTAMP, Timestamp)
+
+    async def kline(
+        self,
+        market: str,
+        *,
+        limit: int = 30,
+        period: int = 1,
+        timestamp: int | None = None,
+    ) -> list[KLine]:
+        payload = await self.endpoint.raw(
+            KLINE,
+            {"market": market, "limit": limit, "period": period, "timestamp": timestamp},
+        )
+        return [
+            KLine(
+                timestamp=int(str(row[0])),
+                open=str(row[1]),
+                high=str(row[2]),
+                low=str(row[3]),
+                close=str(row[4]),
+                volume=str(row[5]),
+            )
+            for row in cast("list[Sequence[object]]", payload)
+        ]
+
+    async def depth(self, market: str, *, limit: int | None = None, sort_by_price: bool | None = None) -> Depth:
+        return await self.endpoint.model(
+            DEPTH,
+            Depth,
+            {"market": market, "limit": limit, "sort_by_price": sort_by_price},
+        )
+
+    async def trades(self, market: str, *, timestamp: int | None = None, limit: int | None = None) -> list[PublicTrade]:
+        return await self.endpoint.model_list(
+            TRADES,
+            PublicTrade,
+            {"market": market, "timestamp": timestamp, "limit": limit},
+        )
+
+    async def tickers(self, markets: Sequence[str]) -> list[Ticker]:
+        return await self.endpoint.model_list(TICKERS, Ticker, {"markets[]": list(markets)})
+
+    async def ticker(self, market: str) -> Ticker:
+        return await self.endpoint.model(TICKER, Ticker, {"market": market})

--- a/src/maicoin/v3/client.py
+++ b/src/maicoin/v3/client.py
@@ -13,7 +13,6 @@ import asyncio
 import email.utils
 import random
 from collections.abc import AsyncIterator
-from collections.abc import Awaitable
 from collections.abc import Callable
 from collections.abc import Mapping
 from collections.abc import Sequence
@@ -22,13 +21,16 @@ from datetime import UTC
 from datetime import datetime
 from typing import Any
 from typing import Protocol
-from typing import TypeVar
 from typing import cast
 from urllib.parse import urljoin
 
 import httpx
-from pydantic import BaseModel
 
+from maicoin.v3._endpoints import ConvertEndpoints
+from maicoin.v3._endpoints import FundsEndpoints
+from maicoin.v3._endpoints import MWalletEndpoints
+from maicoin.v3._endpoints import OrderIntakeHistoryEndpoints
+from maicoin.v3._endpoints import PublicMarketDataEndpoints
 from maicoin.v3.auth import build_auth_headers
 from maicoin.v3.auth import generate_nonce
 from maicoin.v3.errors import Response
@@ -74,8 +76,6 @@ DEFAULT_TIMEOUT = 10
 """Default per-request timeout in seconds."""
 
 SAFE_RETRY_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
-
-ModelT = TypeVar("ModelT", bound=BaseModel)
 
 
 @dataclass(frozen=True)
@@ -123,55 +123,6 @@ def _retry_after_delay(value: str | None) -> float | None:
     if retry_at.tzinfo is None:
         retry_at = retry_at.replace(tzinfo=UTC)
     return max(0.0, (retry_at - datetime.now(UTC)).total_seconds())
-
-
-def _compact(params: Mapping[str, object | None]) -> dict[str, object]:
-    return {key: value for key, value in params.items() if value is not None}
-
-
-async def _iter_id_paginated[PageItemT](  # noqa: C901
-    fetch_page: Callable[[int | None, int], Awaitable[Sequence[PageItemT]]],
-    item_id: Callable[[PageItemT], int],
-    *,
-    from_id: int | None,
-    page_limit: int,
-    max_items: int | None,
-    max_pages: int | None,
-) -> AsyncIterator[PageItemT]:
-    if page_limit <= 0:
-        msg = "page_limit must be greater than 0"
-        raise ValueError(msg)
-    if max_items == 0 or max_pages == 0:
-        return
-
-    cursor = from_id
-    yielded = 0
-    seen_ids: set[int] = set()
-    page_count = max_pages if max_pages is not None else 2**63
-
-    for page_number in range(page_count):
-        page = await fetch_page(cursor, page_limit)
-        if not page:
-            return
-
-        next_cursor = cursor
-        for item in page:
-            current_id = item_id(item)
-            if current_id in seen_ids:
-                continue
-            seen_ids.add(current_id)
-            yield item
-            yielded += 1
-            if max_items is not None and yielded >= max_items:
-                return
-            if next_cursor is None or current_id > next_cursor:
-                next_cursor = current_id
-
-        if len(page) < page_limit or page_number + 1 >= page_count:
-            return
-        if next_cursor == cursor:
-            return
-        cursor = next_cursor
 
 
 class RequestSession(Protocol):
@@ -237,6 +188,11 @@ class Client:
         self._session: RequestSession | None = session
         self.nonce_factory = nonce_factory
         self.retry_policy = retry_policy or RetryPolicy()
+        self._market_data = PublicMarketDataEndpoints(self)
+        self._orders = OrderIntakeHistoryEndpoints(self)
+        self._funds = FundsEndpoints(self)
+        self._convert = ConvertEndpoints(self)
+        self._m_wallet = MWalletEndpoints(self)
 
     @property
     def session(self) -> RequestSession:
@@ -723,45 +679,6 @@ class Client:
         raise_for_api_error(payload)
         return payload
 
-    async def _request_model(
-        self,
-        model: type[ModelT],
-        method: str,
-        path: str,
-        params: Mapping[str, object] | None = None,
-        *,
-        auth: bool = False,
-    ) -> ModelT:
-        """Execute one endpoint and parse its JSON payload into a Pydantic model."""
-        payload = await self.request(method, path, params=params, auth=auth)
-        return model.model_validate(payload)
-
-    async def _request_model_list(
-        self,
-        model: type[ModelT],
-        method: str,
-        path: str,
-        params: Mapping[str, object] | None = None,
-        *,
-        auth: bool = False,
-    ) -> list[ModelT]:
-        """Execute one endpoint and parse its JSON payload into a list of Pydantic models."""
-        payload = await self.request(method, path, params=params, auth=auth)
-        return [model.model_validate(item) for item in cast("list[object]", payload)]
-
-    async def _request_model_mapping(
-        self,
-        model: type[ModelT],
-        method: str,
-        path: str,
-        params: Mapping[str, object] | None = None,
-        *,
-        auth: bool = False,
-    ) -> dict[str, ModelT]:
-        """Execute one endpoint and parse its JSON payload into a keyed model mapping."""
-        payload = await self.request(method, path, params=params, auth=auth)
-        return {key: model.model_validate(value) for key, value in cast("dict[str, object]", payload).items()}
-
     async def _request_with_retries(self, method: str, url: str, kwargs: Mapping[str, object]) -> Response:
         policy = self.retry_policy
         attempts = max(1, policy.total_attempts)
@@ -804,15 +721,15 @@ class Client:
 
     async def markets(self) -> list[Market]:
         """List all available markets (`GET /api/v3/markets`)."""
-        return await self._request_model_list(Market, "GET", "/api/v3/markets")
+        return await self._market_data.markets()
 
     async def currencies(self) -> list[Currency]:
         """List all supported currencies, including network info (`GET /api/v3/currencies`)."""
-        return await self._request_model_list(Currency, "GET", "/api/v3/currencies")
+        return await self._market_data.currencies()
 
     async def timestamp(self) -> Timestamp:
         """Return the server-side timestamp (`GET /api/v3/timestamp`)."""
-        return await self._request_model(Timestamp, "GET", "/api/v3/timestamp")
+        return await self._market_data.timestamp()
 
     async def kline(
         self,
@@ -822,81 +739,32 @@ class Client:
         period: int = 1,
         timestamp: int | None = None,
     ) -> list[KLine]:
-        """Fetch OHLCV candles for `market` (`GET /api/v3/k`).
-
-        Args:
-            market: Market id, e.g. `"btctwd"`.
-            limit: Number of candles to return (1-10000, default 30).
-            period: Candle period in minutes (1, 5, 15, 30, 60, 120, 240, 360, 720, 1440, 4320, 10080).
-            timestamp: Earliest UNIX timestamp (seconds) to include.
-        """
-        payload = await self.request(
-            "GET",
-            "/api/v3/k",
-            params=_compact({"market": market, "limit": limit, "period": period, "timestamp": timestamp}),
-        )
-        return [
-            KLine(
-                timestamp=int(str(row[0])),
-                open=str(row[1]),
-                high=str(row[2]),
-                low=str(row[3]),
-                close=str(row[4]),
-                volume=str(row[5]),
-            )
-            for row in cast("list[Sequence[object]]", payload)
-        ]
+        """Fetch OHLCV candles for `market` (`GET /api/v3/k`)."""
+        return await self._market_data.kline(market, limit=limit, period=period, timestamp=timestamp)
 
     async def depth(self, market: str, *, limit: int | None = None, sort_by_price: bool | None = None) -> Depth:
-        """Fetch the order book depth for `market` (`GET /api/v3/depth`).
-
-        Args:
-            market: Market id, e.g. `"btctwd"`.
-            limit: Maximum number of price levels per side.
-            sort_by_price: If `True`, sort each side by price.
-        """
-        return await self._request_model(
-            Depth,
-            "GET",
-            "/api/v3/depth",
-            params=_compact({"market": market, "limit": limit, "sort_by_price": sort_by_price}),
-        )
+        """Fetch the order book depth for `market` (`GET /api/v3/depth`)."""
+        return await self._market_data.depth(market, limit=limit, sort_by_price=sort_by_price)
 
     async def trades(self, market: str, *, timestamp: int | None = None, limit: int | None = None) -> list[PublicTrade]:
         """Fetch recent public trades for `market` (`GET /api/v3/trades`)."""
-        return await self._request_model_list(
-            PublicTrade,
-            "GET",
-            "/api/v3/trades",
-            params=_compact({"market": market, "timestamp": timestamp, "limit": limit}),
-        )
+        return await self._market_data.trades(market, timestamp=timestamp, limit=limit)
 
     async def tickers(self, markets: Sequence[str]) -> list[Ticker]:
         """Fetch tickers for several markets in one request (`GET /api/v3/tickers`)."""
-        return await self._request_model_list(Ticker, "GET", "/api/v3/tickers", params={"markets[]": list(markets)})
+        return await self._market_data.tickers(markets)
 
     async def ticker(self, market: str) -> Ticker:
         """Fetch the ticker for a single market (`GET /api/v3/ticker`)."""
-        return await self._request_model(Ticker, "GET", "/api/v3/ticker", params={"market": market})
+        return await self._market_data.ticker(market)
 
     async def info(self) -> UserInfo:
         """Return the authenticated user profile and VIP info (`GET /api/v3/info`)."""
-        return await self._request_model(UserInfo, "GET", "/api/v3/info", auth=True)
+        return await self._orders.info()
 
     async def accounts(self, *, wallet_type: str = "spot", currency: str | None = None) -> list[Account]:
-        """List wallet account balances.
-
-        Args:
-            wallet_type: `"spot"` or `"m"` (M-Wallet).
-            currency: Optional filter, e.g. `"twd"`.
-        """
-        return await self._request_model_list(
-            Account,
-            "GET",
-            f"/api/v3/wallet/{wallet_type}/accounts",
-            params=_compact({"currency": currency}),
-            auth=True,
-        )
+        """List wallet account balances."""
+        return await self._orders.accounts(wallet_type=wallet_type, currency=currency)
 
     async def wallet_trades(
         self,
@@ -909,14 +777,13 @@ class Client:
         limit: int | None = None,
     ) -> list[PrivateTrade]:
         """List the authenticated user's trades for a wallet."""
-        return await self._request_model_list(
-            PrivateTrade,
-            "GET",
-            f"/api/v3/wallet/{wallet_type}/trades",
-            params=_compact(
-                {"market": market, "timestamp": timestamp, "from_id": from_id, "order": order, "limit": limit}
-            ),
-            auth=True,
+        return await self._orders.wallet_trades(
+            wallet_type=wallet_type,
+            market=market,
+            timestamp=timestamp,
+            from_id=from_id,
+            order=order,
+            limit=limit,
         )
 
     async def open_orders(
@@ -929,12 +796,8 @@ class Client:
         limit: int | None = None,
     ) -> list[Order]:
         """List the user's open orders."""
-        return await self._request_model_list(
-            Order,
-            "GET",
-            f"/api/v3/wallet/{wallet_type}/orders/open",
-            params=_compact({"market": market, "timestamp": timestamp, "order_by": order_by, "limit": limit}),
-            auth=True,
+        return await self._orders.open_orders(
+            wallet_type=wallet_type, market=market, timestamp=timestamp, order_by=order_by, limit=limit
         )
 
     async def closed_orders(
@@ -947,12 +810,8 @@ class Client:
         limit: int | None = None,
     ) -> list[Order]:
         """List the user's closed (filled or cancelled) orders."""
-        return await self._request_model_list(
-            Order,
-            "GET",
-            f"/api/v3/wallet/{wallet_type}/orders/closed",
-            params=_compact({"market": market, "timestamp": timestamp, "order_by": order_by, "limit": limit}),
-            auth=True,
+        return await self._orders.closed_orders(
+            wallet_type=wallet_type, market=market, timestamp=timestamp, order_by=order_by, limit=limit
         )
 
     async def order_history(
@@ -963,17 +822,8 @@ class Client:
         from_id: int | None = None,
         limit: int | None = None,
     ) -> list[Order]:
-        """Page through the full order history for a market.
-
-        Use `from_id` to seek past the last id you saw.
-        """
-        return await self._request_model_list(
-            Order,
-            "GET",
-            f"/api/v3/wallet/{wallet_type}/orders/history",
-            params=_compact({"market": market, "from_id": from_id, "limit": limit}),
-            auth=True,
-        )
+        """Page through the full order history for a market."""
+        return await self._orders.order_history(market, wallet_type=wallet_type, from_id=from_id, limit=limit)
 
     async def iter_wallet_trades(
         self,
@@ -987,28 +837,13 @@ class Client:
         max_items: int | None = None,
         max_pages: int | None = None,
     ) -> AsyncIterator[PrivateTrade]:
-        """Iterate wallet trades using the `from_id` cursor.
-
-        The iterator stops when the API returns an empty page, a page smaller
-        than `page_limit`, `max_pages` is reached, or `max_items` have been
-        yielded. Duplicate ids are skipped to protect callers from cursor
-        boundary overlap.
-        """
-
-        async def fetch_page(cursor: int | None, limit: int) -> Sequence[PrivateTrade]:
-            return await self.wallet_trades(
-                wallet_type=wallet_type,
-                market=market,
-                timestamp=timestamp,
-                from_id=cursor,
-                order=order,
-                limit=limit,
-            )
-
-        async for trade in _iter_id_paginated(
-            fetch_page,
-            lambda trade: trade.id,
+        """Iterate wallet trades using the `from_id` cursor."""
+        async for trade in self._orders.iter_wallet_trades(
+            wallet_type=wallet_type,
+            market=market,
+            timestamp=timestamp,
             from_id=from_id,
+            order=order,
             page_limit=page_limit,
             max_items=max_items,
             max_pages=max_pages,
@@ -1025,20 +860,10 @@ class Client:
         max_items: int | None = None,
         max_pages: int | None = None,
     ) -> AsyncIterator[Order]:
-        """Iterate order history using the `from_id` cursor.
-
-        The iterator stops when the API returns an empty page, a page smaller
-        than `page_limit`, `max_pages` is reached, or `max_items` have been
-        yielded. Duplicate ids are skipped to protect callers from cursor
-        boundary overlap.
-        """
-
-        async def fetch_page(cursor: int | None, limit: int) -> Sequence[Order]:
-            return await self.order_history(market, wallet_type=wallet_type, from_id=cursor, limit=limit)
-
-        async for order_item in _iter_id_paginated(
-            fetch_page,
-            lambda order_item: order_item.id,
+        """Iterate order history using the `from_id` cursor."""
+        async for order_item in self._orders.iter_order_history(
+            market,
+            wallet_type=wallet_type,
             from_id=from_id,
             page_limit=page_limit,
             max_items=max_items,
@@ -1048,13 +873,7 @@ class Client:
 
     async def order(self, *, order_id: int | None = None, client_oid: str | None = None) -> Order:
         """Fetch a single order by `order_id` or `client_oid`."""
-        return await self._request_model(
-            Order,
-            "GET",
-            "/api/v3/order",
-            params=_compact({"id": order_id, "client_oid": client_oid}),
-            auth=True,
-        )
+        return await self._orders.order(order_id=order_id, client_oid=client_oid)
 
     async def create_order(
         self,
@@ -1069,51 +888,22 @@ class Client:
         ord_type: OrderType | str | None = None,
         group_id: int | None = None,
     ) -> Order:
-        """Place a new order.
-
-        !!! warning
-            This is a state-changing endpoint. Double-check `market`, `side`,
-            `volume`, and `price` before calling against a live account.
-
-        Args:
-            market: Market id, e.g. `"btctwd"`.
-            side: `"buy"` or `"sell"` (or [`OrderSide`][maicoin.v3.OrderSide]).
-            volume: Order amount as a decimal string.
-            wallet_type: `"spot"` or `"m"`.
-            price: Limit price. Omit for market orders.
-            client_oid: Optional client-side order id for idempotency.
-            stop_price: Trigger price for stop orders.
-            ord_type: One of [`OrderType`][maicoin.v3.OrderType] (e.g. `"limit"`, `"market"`, `"stop_limit"`).
-            group_id: Group id for OCO/grouped cancellation.
-        """
-        return await self._request_model(
-            Order,
-            "POST",
-            f"/api/v3/wallet/{wallet_type}/order",
-            params=_compact(
-                {
-                    "market": market,
-                    "side": side,
-                    "volume": volume,
-                    "price": price,
-                    "client_oid": client_oid,
-                    "stop_price": stop_price,
-                    "ord_type": ord_type,
-                    "group_id": group_id,
-                }
-            ),
-            auth=True,
+        """Place a new order."""
+        return await self._orders.create_order(
+            market,
+            side,
+            volume,
+            wallet_type=wallet_type,
+            price=price,
+            client_oid=client_oid,
+            stop_price=stop_price,
+            ord_type=ord_type,
+            group_id=group_id,
         )
 
     async def cancel_order(self, *, order_id: int | None = None, client_oid: str | None = None) -> Order:
         """Cancel an order by `order_id` or `client_oid`."""
-        return await self._request_model(
-            Order,
-            "DELETE",
-            "/api/v3/order",
-            params=_compact({"id": order_id, "client_oid": client_oid}),
-            auth=True,
-        )
+        return await self._orders.cancel_order(order_id=order_id, client_oid=client_oid)
 
     async def cancel_orders(
         self,
@@ -1124,51 +914,23 @@ class Client:
         group_id: int | None = None,
     ) -> list[Order]:
         """Bulk-cancel orders. Filters compose: omit them all to cancel everything in the wallet."""
-        return await self._request_model_list(
-            Order,
-            "DELETE",
-            f"/api/v3/wallet/{wallet_type}/orders",
-            params=_compact({"market": market, "side": side, "group_id": group_id}),
-            auth=True,
-        )
+        return await self._orders.cancel_orders(wallet_type=wallet_type, market=market, side=side, group_id=group_id)
 
     async def order_trades(self, *, order_id: int | None = None, client_oid: str | None = None) -> list[PrivateTrade]:
         """List the executed trades for one order."""
-        return await self._request_model_list(
-            PrivateTrade,
-            "GET",
-            "/api/v3/order/trades",
-            params=_compact({"order_id": order_id, "client_oid": client_oid}),
-            auth=True,
-        )
+        return await self._orders.order_trades(order_id=order_id, client_oid=client_oid)
 
     async def withdrawal(self, uuid: str) -> Withdrawal:
         """Look up a withdrawal by its `uuid`."""
-        return await self._request_model(Withdrawal, "GET", "/api/v3/withdrawal", params={"uuid": uuid}, auth=True)
+        return await self._funds.withdrawal(uuid)
 
     async def create_withdrawal(self, *, withdraw_address_uuid: str, amount: str) -> Withdrawal:
-        """Submit a crypto withdrawal to a pre-approved address.
-
-        !!! warning
-            State-changing. The address must already be whitelisted on MAX.
-        """
-        return await self._request_model(
-            Withdrawal,
-            "POST",
-            "/api/v3/withdrawal",
-            params={"withdraw_address_uuid": withdraw_address_uuid, "amount": amount},
-            auth=True,
-        )
+        """Submit a crypto withdrawal to a pre-approved address."""
+        return await self._funds.create_withdrawal(withdraw_address_uuid=withdraw_address_uuid, amount=amount)
 
     async def create_twd_withdrawal(self, amount: str) -> Withdrawal:
-        """Submit a TWD bank withdrawal.
-
-        !!! warning
-            State-changing. The default bank account on file is debited.
-        """
-        return await self._request_model(
-            Withdrawal, "POST", "/api/v3/withdrawal/twd", params={"amount": amount}, auth=True
-        )
+        """Submit a TWD bank withdrawal."""
+        return await self._funds.create_twd_withdrawal(amount)
 
     async def withdrawals(
         self,
@@ -1180,14 +942,8 @@ class Client:
         limit: int | None = None,
     ) -> list[Withdrawal]:
         """List withdrawal history."""
-        return await self._request_model_list(
-            Withdrawal,
-            "GET",
-            "/api/v3/withdrawals",
-            params=_compact(
-                {"currency": currency, "state": state, "timestamp": timestamp, "order": order, "limit": limit}
-            ),
-            auth=True,
+        return await self._funds.withdrawals(
+            currency=currency, state=state, timestamp=timestamp, order=order, limit=limit
         )
 
     async def withdraw_addresses(
@@ -1198,19 +954,11 @@ class Client:
         offset: int | None = None,
     ) -> list[WithdrawAddress]:
         """List the user's whitelisted withdrawal addresses for `currency`."""
-        return await self._request_model_list(
-            WithdrawAddress,
-            "GET",
-            "/api/v3/withdraw_addresses",
-            params=_compact({"currency": currency, "limit": limit, "offset": offset}),
-            auth=True,
-        )
+        return await self._funds.withdraw_addresses(currency, limit=limit, offset=offset)
 
     async def deposit(self, *, txid: str | None = None, uuid: str | None = None) -> Deposit:
         """Look up a deposit by `txid` or `uuid`."""
-        return await self._request_model(
-            Deposit, "GET", "/api/v3/deposit", params=_compact({"txid": txid, "uuid": uuid}), auth=True
-        )
+        return await self._funds.deposit(txid=txid, uuid=uuid)
 
     async def deposits(
         self,
@@ -1221,23 +969,11 @@ class Client:
         limit: int | None = None,
     ) -> list[Deposit]:
         """List deposit history."""
-        return await self._request_model_list(
-            Deposit,
-            "GET",
-            "/api/v3/deposits",
-            params=_compact({"currency": currency, "timestamp": timestamp, "order": order, "limit": limit}),
-            auth=True,
-        )
+        return await self._funds.deposits(currency=currency, timestamp=timestamp, order=order, limit=limit)
 
     async def deposit_address(self, currency_version: str) -> DepositAddress:
         """Get the deposit address for a specific currency/network version."""
-        return await self._request_model(
-            DepositAddress,
-            "GET",
-            "/api/v3/deposit_address",
-            params={"currency_version": currency_version},
-            auth=True,
-        )
+        return await self._funds.deposit_address(currency_version)
 
     async def internal_transfers(
         self,
@@ -1248,19 +984,9 @@ class Client:
         order: str | None = None,
         limit: int | None = None,
     ) -> list[InternalTransfer]:
-        """List internal transfers between MAX users.
-
-        Args:
-            side: `"in"` or `"out"`.
-        """
-        return await self._request_model_list(
-            InternalTransfer,
-            "GET",
-            "/api/v3/internal_transfers",
-            params=_compact(
-                {"side": side, "currency": currency, "timestamp": timestamp, "order": order, "limit": limit}
-            ),
-            auth=True,
+        """List internal transfers between MAX users."""
+        return await self._funds.internal_transfers(
+            side, currency=currency, timestamp=timestamp, order=order, limit=limit
         )
 
     async def rewards(
@@ -1273,75 +999,39 @@ class Client:
         limit: int | None = None,
     ) -> list[Reward]:
         """List reward history (referrals, mining, staking, etc.)."""
-        return await self._request_model_list(
-            Reward,
-            "GET",
-            "/api/v3/rewards",
-            params=_compact(
-                {
-                    "reward_type": reward_type,
-                    "currency": currency,
-                    "timestamp": timestamp,
-                    "order": order,
-                    "limit": limit,
-                }
-            ),
-            auth=True,
+        return await self._funds.rewards(
+            reward_type=reward_type, currency=currency, timestamp=timestamp, order=order, limit=limit
         )
 
     async def fund_transaction_deposits(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[FundTransactionDeposit]:
         """List fund-transaction deposits (off-exchange settlement)."""
-        return await self._request_model_list(
-            FundTransactionDeposit,
-            "GET",
-            "/api/v3/fund_transactions/deposits",
-            params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
-            auth=True,
-        )
+        return await self._funds.fund_transaction_deposits(timestamp=timestamp, order=order, limit=limit)
 
     async def fund_transaction_deposit(self, sn: str) -> FundTransactionDeposit:
         """Look up a fund-transaction deposit by `sn`."""
-        return await self._request_model(
-            FundTransactionDeposit, "GET", "/api/v3/fund_transactions/deposit", params={"sn": sn}, auth=True
-        )
+        return await self._funds.fund_transaction_deposit(sn)
 
     async def fund_transaction_withdrawals(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[FundTransactionWithdrawal]:
         """List fund-transaction withdrawals."""
-        return await self._request_model_list(
-            FundTransactionWithdrawal,
-            "GET",
-            "/api/v3/fund_transactions/withdrawals",
-            params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
-            auth=True,
-        )
+        return await self._funds.fund_transaction_withdrawals(timestamp=timestamp, order=order, limit=limit)
 
     async def fund_transaction_withdrawal(self, sn: str) -> FundTransactionWithdrawal:
         """Look up a fund-transaction withdrawal by `sn`."""
-        return await self._request_model(
-            FundTransactionWithdrawal, "GET", "/api/v3/fund_transactions/withdrawal", params={"sn": sn}, auth=True
-        )
+        return await self._funds.fund_transaction_withdrawal(sn)
 
     async def fund_transaction_transfers(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[FundTransactionTransfer]:
         """List fund-transaction transfers."""
-        return await self._request_model_list(
-            FundTransactionTransfer,
-            "GET",
-            "/api/v3/fund_transactions/transfers",
-            params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
-            auth=True,
-        )
+        return await self._funds.fund_transaction_transfers(timestamp=timestamp, order=order, limit=limit)
 
     async def fund_transaction_transfer(self, sn: str) -> FundTransactionTransfer:
         """Look up a fund-transaction transfer by `sn`."""
-        return await self._request_model(
-            FundTransactionTransfer, "GET", "/api/v3/fund_transactions/transfer", params={"sn": sn}, auth=True
-        )
+        return await self._funds.fund_transaction_transfer(sn)
 
     async def create_convert(
         self,
@@ -1351,45 +1041,24 @@ class Client:
         from_amount: str | None = None,
         to_amount: str | None = None,
     ) -> ConvertOrder:
-        """Submit a convert order between two currencies.
-
-        Specify exactly one of `from_amount` or `to_amount`.
-        """
-        return await self._request_model(
-            ConvertOrder,
-            "POST",
-            "/api/v3/convert",
-            params=_compact(
-                {
-                    "from_currency": from_currency,
-                    "to_currency": to_currency,
-                    "from_amount": from_amount,
-                    "to_amount": to_amount,
-                }
-            ),
-            auth=True,
+        """Submit a convert order between two currencies."""
+        return await self._convert.create_convert(
+            from_currency=from_currency, to_currency=to_currency, from_amount=from_amount, to_amount=to_amount
         )
 
     async def convert(self, sn: str) -> ConvertOrder:
         """Look up a convert order by `sn`."""
-        return await self._request_model(ConvertOrder, "GET", "/api/v3/convert", params={"sn": sn}, auth=True)
+        return await self._convert.convert(sn)
 
     async def converts(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[ConvertOrder]:
         """List convert order history."""
-        return await self._request_model_list(
-            ConvertOrder,
-            "GET",
-            "/api/v3/converts",
-            params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
-            auth=True,
-        )
+        return await self._convert.converts(timestamp=timestamp, order=order, limit=limit)
 
     async def m_wallet_index_prices(self) -> dict[str, str]:
         """Return current M-Wallet index prices keyed by market id."""
-        payload = await self.request("GET", "/api/v3/wallet/m/index_prices")
-        return cast("dict[str, str]", payload)
+        return await self._m_wallet.m_wallet_index_prices()
 
     async def m_wallet_historical_index_prices(
         self,
@@ -1398,75 +1067,30 @@ class Client:
         start_time: int,
         end_time: int,
     ) -> list[HistoricalIndexPrice]:
-        """Fetch historical M-Wallet index prices for `market`.
-
-        Args:
-            market: Market id.
-            start_time: Inclusive start (UNIX milliseconds).
-            end_time: Inclusive end (UNIX milliseconds).
-        """
-        return await self._request_model_list(
-            HistoricalIndexPrice,
-            "GET",
-            "/api/v3/wallet/m/historical_index_prices",
-            params={"market": market, "start_time": start_time, "end_time": end_time},
-        )
+        """Fetch historical M-Wallet index prices for `market`."""
+        return await self._m_wallet.m_wallet_historical_index_prices(market, start_time=start_time, end_time=end_time)
 
     async def m_wallet_limits(self) -> dict[str, str]:
         """Return per-currency M-Wallet borrow limits."""
-        payload = await self.request("GET", "/api/v3/wallet/m/limits")
-        return cast("dict[str, str]", payload)
+        return await self._m_wallet.m_wallet_limits()
 
     async def m_wallet_interest_rates(self) -> dict[str, InterestRate]:
         """Return current M-Wallet interest rates per currency."""
-        return await self._request_model_mapping(InterestRate, "GET", "/api/v3/wallet/m/interest_rates")
+        return await self._m_wallet.m_wallet_interest_rates()
 
     async def create_m_wallet_loan(self, *, currency: str, amount: str) -> MWalletLoan:
-        """Borrow `amount` of `currency` into the M-Wallet.
-
-        !!! warning
-            State-changing — accrues interest until repaid.
-        """
-        return await self._request_model(
-            MWalletLoan,
-            "POST",
-            "/api/v3/wallet/m/loan",
-            params={"currency": currency, "amount": amount},
-            auth=True,
-        )
+        """Borrow `amount` of `currency` into the M-Wallet."""
+        return await self._m_wallet.create_m_wallet_loan(currency=currency, amount=amount)
 
     async def m_wallet_loans(
-        self,
-        currency: str,
-        *,
-        timestamp: int | None = None,
-        order: str | None = None,
-        limit: int | None = None,
+        self, currency: str, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[MWalletLoan]:
         """List M-Wallet loans for `currency`."""
-        return await self._request_model_list(
-            MWalletLoan,
-            "GET",
-            "/api/v3/wallet/m/loans",
-            params=_compact({"currency": currency, "timestamp": timestamp, "order": order, "limit": limit}),
-            auth=True,
-        )
+        return await self._m_wallet.m_wallet_loans(currency, timestamp=timestamp, order=order, limit=limit)
 
     async def create_m_wallet_transfer(self, *, currency: str, amount: str, side: str) -> MWalletTransfer:
-        """Transfer between spot and M-Wallet.
-
-        Args:
-            currency: Currency code.
-            amount: Decimal amount as a string.
-            side: `"in"` (spot → M-Wallet) or `"out"` (M-Wallet → spot).
-        """
-        return await self._request_model(
-            MWalletTransfer,
-            "POST",
-            "/api/v3/wallet/m/transfer",
-            params={"currency": currency, "amount": amount, "side": side},
-            auth=True,
-        )
+        """Transfer between spot and M-Wallet."""
+        return await self._m_wallet.create_m_wallet_transfer(currency=currency, amount=amount, side=side)
 
     async def m_wallet_transfers(
         self,
@@ -1478,64 +1102,29 @@ class Client:
         limit: int | None = None,
     ) -> list[MWalletTransfer]:
         """List M-Wallet transfer history."""
-        return await self._request_model_list(
-            MWalletTransfer,
-            "GET",
-            "/api/v3/wallet/m/transfers",
-            params=_compact(
-                {"currency": currency, "side": side, "timestamp": timestamp, "order": order, "limit": limit}
-            ),
-            auth=True,
+        return await self._m_wallet.m_wallet_transfers(
+            currency=currency, side=side, timestamp=timestamp, order=order, limit=limit
         )
 
     async def create_m_wallet_repayment(self, *, currency: str, amount: str) -> MWalletRepayment:
-        """Repay an M-Wallet loan.
-
-        !!! warning
-            State-changing.
-        """
-        return await self._request_model(
-            MWalletRepayment,
-            "POST",
-            "/api/v3/wallet/m/repayment",
-            params={"currency": currency, "amount": amount},
-            auth=True,
-        )
+        """Repay an M-Wallet loan."""
+        return await self._m_wallet.create_m_wallet_repayment(currency=currency, amount=amount)
 
     async def m_wallet_repayments(
-        self,
-        currency: str,
-        *,
-        timestamp: int | None = None,
-        order: str | None = None,
-        limit: int | None = None,
+        self, currency: str, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[MWalletRepayment]:
         """List M-Wallet repayment history for `currency`."""
-        return await self._request_model_list(
-            MWalletRepayment,
-            "GET",
-            "/api/v3/wallet/m/repayments",
-            params=_compact({"currency": currency, "timestamp": timestamp, "order": order, "limit": limit}),
-            auth=True,
-        )
+        return await self._m_wallet.m_wallet_repayments(currency, timestamp=timestamp, order=order, limit=limit)
 
     async def m_wallet_liquidations(
         self, *, timestamp: int | None = None, order: str | None = None, limit: int | None = None
     ) -> list[MWalletLiquidation]:
         """List M-Wallet liquidation events."""
-        return await self._request_model_list(
-            MWalletLiquidation,
-            "GET",
-            "/api/v3/wallet/m/liquidations",
-            params=_compact({"timestamp": timestamp, "order": order, "limit": limit}),
-            auth=True,
-        )
+        return await self._m_wallet.m_wallet_liquidations(timestamp=timestamp, order=order, limit=limit)
 
     async def m_wallet_liquidation(self, sn: str) -> MWalletLiquidationDetail:
         """Look up a single M-Wallet liquidation, including order/repayment details."""
-        return await self._request_model(
-            MWalletLiquidationDetail, "GET", "/api/v3/wallet/m/liquidation", params={"sn": sn}, auth=True
-        )
+        return await self._m_wallet.m_wallet_liquidation(sn)
 
     async def m_wallet_interests(
         self,
@@ -1546,14 +1135,8 @@ class Client:
         limit: int | None = None,
     ) -> list[MWalletInterest]:
         """List M-Wallet interest accruals."""
-        return await self._request_model_list(
-            MWalletInterest,
-            "GET",
-            "/api/v3/wallet/m/interests",
-            params=_compact({"currency": currency, "timestamp": timestamp, "order": order, "limit": limit}),
-            auth=True,
-        )
+        return await self._m_wallet.m_wallet_interests(currency=currency, timestamp=timestamp, order=order, limit=limit)
 
     async def m_wallet_ad_ratio(self) -> MWalletADRatio:
         """Return the M-Wallet account debt ratio (asset-to-debt and margin level)."""
-        return await self._request_model(MWalletADRatio, "GET", "/api/v3/wallet/m/ad_ratio", auth=True)
+        return await self._m_wallet.m_wallet_ad_ratio()

--- a/tests/v3/test_client.py
+++ b/tests/v3/test_client.py
@@ -5,6 +5,8 @@ from typing import cast
 
 import pytest
 
+from maicoin.v3._endpoints.base import EndpointExecutor
+from maicoin.v3._endpoints.base import EndpointSpec
 from maicoin.v3.client import Client
 from maicoin.v3.client import RetryPolicy
 from maicoin.v3.errors import MaxAPIError
@@ -129,7 +131,7 @@ async def test_authenticated_request_requires_credentials() -> None:
         await client.request("GET", "/api/v3/wallet/spot/accounts", auth=True)
 
 
-async def test_request_model_helpers_preserve_request_conventions_and_parse_payloads() -> None:
+async def test_endpoint_executor_preserves_request_conventions_and_parse_payloads() -> None:
     market_payload = {
         "id": "btctwd",
         "status": "enabled",
@@ -148,11 +150,22 @@ async def test_request_model_helpers_preserve_request_conventions_and_parse_payl
             FakeResponse({"btc": {"hourly_interest_rate": "0.0003", "next_hourly_interest_rate": "0.0004"}}),
         ]
     )
-    client = Client(base_url="https://example.test", session=session)
+    client = Client(
+        api_key="key",
+        api_secret="secret",
+        base_url="https://example.test",
+        session=session,
+        nonce_factory=lambda: 123456,
+    )
+    endpoint = EndpointExecutor(client)
 
-    timestamp = await client._request_model(Timestamp, "GET", "/api/v3/timestamp")
-    markets = await client._request_model_list(Market, "GET", "/api/v3/markets")
-    rates = await client._request_model_mapping(InterestRate, "GET", "/api/v3/wallet/m/interest_rates")
+    timestamp = await endpoint.model(EndpointSpec("GET", "/api/v3/timestamp"), Timestamp)
+    markets = await endpoint.model_list(EndpointSpec("GET", "/api/v3/markets"), Market)
+    rates = await endpoint.model_mapping(
+        EndpointSpec("GET", "/api/v3/wallet/m/interest_rates", auth=True),
+        InterestRate,
+        {"currency": None},
+    )
 
     assert timestamp.timestamp == 1678766175
     assert markets == [Market.model_validate(market_payload)]
@@ -162,6 +175,7 @@ async def test_request_model_helpers_preserve_request_conventions_and_parse_payl
         "https://example.test/api/v3/markets",
         "https://example.test/api/v3/wallet/m/interest_rates",
     ]
+    assert cast("dict[str, object]", session.calls[-1]["kwargs"])["params"] == {"nonce": 123456}
 
 
 async def test_get_request_retries_retry_after_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Move REST v3 endpoint-family request and parsing rules into internal `_endpoints` modules.
- Add `EndpointSpec` and `EndpointExecutor` to centralize method/path/auth metadata, param compaction, and model/list/mapping parsing.
- Keep public `Client` method signatures stable while making methods delegate to public market data, order, funds, convert, and M-Wallet families.

## Tests
- `just`