### PR TITLE
docs: add websocket reconnect policy reference

### DIFF
--- a/docs/reference/ws.md
+++ b/docs/reference/ws.md
@@ -5,6 +5,7 @@ WebSocket stream client and channel models for MAX.
 ## Stream
 
 ::: maicoin.ws.Stream
+::: maicoin.ws.ReconnectPolicy
 
 ## Subscriptions and requests
 


### PR DESCRIPTION
## Summary
- Add `maicoin.ws.ReconnectPolicy` to the WebSocket API reference so autorefs can resolve the reconnect-policy link from the WebSocket guide.

## Tests
- `just docs-build`