### PR TITLE
test(v3): deepen REST client harness

### DIFF
--- a/.agents/docs/TODO.md
+++ b/.agents/docs/TODO.md
@@ -11,7 +11,7 @@ Follow-up plans:
 
 Plan: [`plans/codebase-architecture-deepening-opportunities.md`](plans/codebase-architecture-deepening-opportunities.md)
 
-- [ ] Deepen the REST v3 test harness so fake transport, authenticated clients, request inspection, and auth payload decoding live behind one test Module.
+- [x] Deepen the REST v3 test harness so fake transport, authenticated clients, request inspection, and auth payload decoding live behind one test Module.
 - [x] Split REST v3 raw models by domain family while preserving public `maicoin.v3` and `maicoin.v3.models` imports.
 - [ ] Deepen the WebSocket Stream lifecycle implementation so reconnect/session and response dispatch rules have stronger locality.
 - [ ] Add a public export / docs-reference consistency check to prevent strict MkDocs autorefs drift.

--- a/tests/v3/helpers.py
+++ b/tests/v3/helpers.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Mapping
+from typing import cast
+
+from maicoin.v3 import Client
+
+BASE_URL = "https://example.test"
+FIXED_NONCE = 123456
+API_KEY = "key"
+API_SECRET = "secret"
+
+
+class FakeResponse:
+    def __init__(self, payload: object, *, status_code: int = 200, headers: Mapping[str, str] | None = None) -> None:
+        self.payload = payload
+        self.status_code = status_code
+        self.headers = dict(headers or {})
+        self.content = b"{}"
+        self.text = str(payload)
+
+    def json(self) -> object:
+        return self.payload
+
+
+class FakeSession:
+    def __init__(self, response: object) -> None:
+        if isinstance(response, FakeResponse):
+            self.responses: list[FakeResponse] = [response]
+        elif isinstance(response, list) and all(isinstance(item, FakeResponse) for item in response):
+            self.responses = cast("list[FakeResponse]", response)
+        else:
+            self.responses = [FakeResponse(response)]
+        self.calls: list[dict[str, object]] = []
+        self.closed = False
+
+    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        if len(self.responses) == 1:
+            return self.responses[0]
+        return self.responses.pop(0)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class PagedFakeSession:
+    def __init__(self, pages: list[object]) -> None:
+        self.pages = pages
+        self.calls: list[dict[str, object]] = []
+        self.closed = False
+
+    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        page = self.pages[len(self.calls) - 1]
+        return FakeResponse(page)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def public_client(session: FakeSession | PagedFakeSession) -> Client:
+    return Client(base_url=BASE_URL, session=session)
+
+
+def authenticated_client(session: FakeSession | PagedFakeSession) -> Client:
+    return Client(
+        api_key=API_KEY,
+        api_secret=API_SECRET,
+        base_url=BASE_URL,
+        session=session,
+        nonce_factory=lambda: FIXED_NONCE,
+    )
+
+
+def last_call(session: FakeSession | PagedFakeSession) -> Mapping[str, object]:
+    return cast("Mapping[str, object]", session.calls[-1])
+
+
+def call_kwargs(session: FakeSession | PagedFakeSession, index: int = -1) -> Mapping[str, object]:
+    return cast("Mapping[str, object]", session.calls[index]["kwargs"])
+
+
+def last_kwargs(session: FakeSession | PagedFakeSession) -> Mapping[str, object]:
+    return call_kwargs(session)
+
+
+def last_params(session: FakeSession | PagedFakeSession) -> Mapping[str, object]:
+    return cast("Mapping[str, object]", last_kwargs(session)["params"])
+
+
+def last_json(session: FakeSession | PagedFakeSession) -> Mapping[str, object]:
+    return cast("Mapping[str, object]", last_kwargs(session)["json"])
+
+
+def request_headers(session: FakeSession | PagedFakeSession, index: int = -1) -> Mapping[str, str]:
+    return cast("Mapping[str, str]", call_kwargs(session, index)["headers"])
+
+
+def auth_payload(session: FakeSession | PagedFakeSession, index: int = -1) -> Mapping[str, object]:
+    headers = request_headers(session, index)
+    payload = base64.b64decode(headers["X-MAX-PAYLOAD"]).decode()
+    return cast("Mapping[str, object]", json.loads(payload))
+
+
+def last_payload(session: FakeSession | PagedFakeSession) -> Mapping[str, object]:
+    return auth_payload(session)

--- a/tests/v3/test_client.py
+++ b/tests/v3/test_client.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import cast
-
 import pytest
 
 from maicoin.v3._endpoints.base import EndpointExecutor
@@ -14,40 +11,12 @@ from maicoin.v3.errors import MaxHTTPError
 from maicoin.v3.models import InterestRate
 from maicoin.v3.models import Market
 from maicoin.v3.models import Timestamp
+from tests.v3.helpers import FakeResponse
+from tests.v3.helpers import FakeSession
+from tests.v3.helpers import last_kwargs
+from tests.v3.helpers import request_headers
 
 pytestmark = pytest.mark.anyio
-
-
-class FakeResponse:
-    def __init__(self, payload: object, *, status_code: int = 200, headers: Mapping[str, str] | None = None) -> None:
-        self.payload = payload
-        self.status_code = status_code
-        self.headers = dict(headers or {})
-        self.content = b"{}"
-        self.text = str(payload)
-
-    def json(self) -> object:
-        return self.payload
-
-
-class FakeSession:
-    def __init__(self, response: FakeResponse | list[FakeResponse]) -> None:
-        self.responses = [response] if isinstance(response, FakeResponse) else response
-        self.calls: list[dict[str, object]] = []
-        self.closed = False
-
-    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
-        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-        if len(self.responses) == 1:
-            return self.responses[0]
-        return self.responses.pop(0)
-
-    async def aclose(self) -> None:
-        self.closed = True
-
-
-def last_kwargs(session: FakeSession) -> Mapping[str, object]:
-    return cast("Mapping[str, object]", session.calls[-1]["kwargs"])
 
 
 async def test_get_request_sends_params_as_query_params() -> None:
@@ -97,7 +66,7 @@ async def test_authenticated_request_adds_max_headers() -> None:
 
     await client.request("GET", "/api/v3/wallet/spot/accounts", params={"currency": "btc"}, auth=True)
 
-    headers = cast("Mapping[str, str]", last_kwargs(session)["headers"])
+    headers = request_headers(session)
     assert headers["X-MAX-ACCESSKEY"] == "key"
     assert headers["X-MAX-PAYLOAD"] == (
         "eyJub25jZSI6MTIzNDU2LCJjdXJyZW5jeSI6ImJ0YyIsInBhdGgiOiIvYXBpL3YzL3dhbGxldC9zcG90L2FjY291bnRzIn0="
@@ -175,7 +144,7 @@ async def test_endpoint_executor_preserves_request_conventions_and_parse_payload
         "https://example.test/api/v3/markets",
         "https://example.test/api/v3/wallet/m/interest_rates",
     ]
-    assert cast("dict[str, object]", session.calls[-1]["kwargs"])["params"] == {"nonce": 123456}
+    assert last_kwargs(session)["params"] == {"nonce": 123456}
 
 
 async def test_get_request_retries_retry_after_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/v3/test_convert.py
+++ b/tests/v3/test_convert.py
@@ -1,57 +1,15 @@
 from __future__ import annotations
 
-import base64
-import json
-from collections.abc import Mapping
-from typing import cast
-
 import pytest
 
-from maicoin.v3 import Client
 from maicoin.v3 import ConvertOrder
+from tests.v3.helpers import FakeSession
+from tests.v3.helpers import authenticated_client
+from tests.v3.helpers import last_json
+from tests.v3.helpers import last_kwargs
+from tests.v3.helpers import last_payload
 
 pytestmark = pytest.mark.anyio
-
-
-class FakeResponse:
-    def __init__(self, payload: object) -> None:
-        self.payload = payload
-        self.status_code = 200
-        self.content = b"{}"
-        self.text = str(payload)
-
-    def json(self) -> object:
-        return self.payload
-
-
-class FakeSession:
-    def __init__(self, payload: object) -> None:
-        self.response = FakeResponse(payload)
-        self.calls: list[dict[str, object]] = []
-
-    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
-        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-        return self.response
-
-
-def authenticated_client(session: FakeSession) -> Client:
-    return Client(
-        api_key="key",
-        api_secret="secret",
-        base_url="https://example.test",
-        session=session,
-        nonce_factory=lambda: 123456,
-    )
-
-
-def last_kwargs(session: FakeSession) -> Mapping[str, object]:
-    return cast("Mapping[str, object]", session.calls[-1]["kwargs"])
-
-
-def last_payload(session: FakeSession) -> Mapping[str, object]:
-    headers = cast("Mapping[str, str]", last_kwargs(session)["headers"])
-    payload = base64.b64decode(headers["X-MAX-PAYLOAD"]).decode()
-    return cast("Mapping[str, object]", json.loads(payload))
 
 
 def convert_payload(**overrides: object) -> dict[str, object]:
@@ -81,7 +39,7 @@ async def test_create_convert_constructs_authenticated_post_and_parses_payload()
     assert convert == ConvertOrder.model_validate(convert_payload())
     assert session.calls[-1]["method"] == "POST"
     assert session.calls[-1]["url"] == "https://example.test/api/v3/convert"
-    assert last_kwargs(session)["json"] == {
+    assert last_json(session) == {
         "nonce": 123456,
         "from_currency": "btc",
         "to_currency": "usdt",

--- a/tests/v3/test_funds.py
+++ b/tests/v3/test_funds.py
@@ -1,13 +1,7 @@
 from __future__ import annotations
 
-import base64
-import json
-from collections.abc import Mapping
-from typing import cast
-
 import pytest
 
-from maicoin.v3 import Client
 from maicoin.v3 import Deposit
 from maicoin.v3 import DepositAddress
 from maicoin.v3 import FundTransactionDeposit
@@ -17,49 +11,13 @@ from maicoin.v3 import InternalTransfer
 from maicoin.v3 import Reward
 from maicoin.v3 import WithdrawAddress
 from maicoin.v3 import Withdrawal
+from tests.v3.helpers import FakeSession
+from tests.v3.helpers import authenticated_client
+from tests.v3.helpers import last_json
+from tests.v3.helpers import last_kwargs
+from tests.v3.helpers import last_payload
 
 pytestmark = pytest.mark.anyio
-
-
-class FakeResponse:
-    def __init__(self, payload: object) -> None:
-        self.payload = payload
-        self.status_code = 200
-        self.content = b"{}"
-        self.text = str(payload)
-
-    def json(self) -> object:
-        return self.payload
-
-
-class FakeSession:
-    def __init__(self, payload: object) -> None:
-        self.response = FakeResponse(payload)
-        self.calls: list[dict[str, object]] = []
-
-    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
-        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-        return self.response
-
-
-def authenticated_client(session: FakeSession) -> Client:
-    return Client(
-        api_key="key",
-        api_secret="secret",
-        base_url="https://example.test",
-        session=session,
-        nonce_factory=lambda: 123456,
-    )
-
-
-def last_kwargs(session: FakeSession) -> Mapping[str, object]:
-    return cast("Mapping[str, object]", session.calls[-1]["kwargs"])
-
-
-def last_payload(session: FakeSession) -> Mapping[str, object]:
-    headers = cast("Mapping[str, str]", last_kwargs(session)["headers"])
-    payload = base64.b64decode(headers["X-MAX-PAYLOAD"]).decode()
-    return cast("Mapping[str, object]", json.loads(payload))
 
 
 def withdrawal_payload(**overrides: object) -> dict[str, object]:
@@ -160,7 +118,7 @@ async def test_withdrawal_methods_construct_authenticated_requests_and_parse_pay
     create_session = FakeSession(withdrawal_payload())
     await authenticated_client(create_session).create_withdrawal(withdraw_address_uuid="addr-1", amount="0.019")
     assert create_session.calls[-1]["method"] == "POST"
-    assert last_kwargs(create_session)["json"] == {
+    assert last_json(create_session) == {
         "nonce": 123456,
         "withdraw_address_uuid": "addr-1",
         "amount": "0.019",
@@ -170,7 +128,7 @@ async def test_withdrawal_methods_construct_authenticated_requests_and_parse_pay
     twd_session = FakeSession(withdrawal_payload(currency="twd", network_protocol=None, amount="100"))
     await authenticated_client(twd_session).create_twd_withdrawal("100")
     assert twd_session.calls[-1]["url"] == "https://example.test/api/v3/withdrawal/twd"
-    assert last_kwargs(twd_session)["json"] == {"nonce": 123456, "amount": "100"}
+    assert last_json(twd_session) == {"nonce": 123456, "amount": "100"}
 
 
 async def test_withdrawals_and_withdraw_addresses_parse_lists() -> None:

--- a/tests/v3/test_m_wallet_private.py
+++ b/tests/v3/test_m_wallet_private.py
@@ -1,13 +1,7 @@
 from __future__ import annotations
 
-import base64
-import json
-from collections.abc import Mapping
-from typing import cast
-
 import pytest
 
-from maicoin.v3 import Client
 from maicoin.v3 import MWalletADRatio
 from maicoin.v3 import MWalletInterest
 from maicoin.v3 import MWalletLiquidation
@@ -15,49 +9,13 @@ from maicoin.v3 import MWalletLiquidationDetail
 from maicoin.v3 import MWalletLoan
 from maicoin.v3 import MWalletRepayment
 from maicoin.v3 import MWalletTransfer
+from tests.v3.helpers import FakeSession
+from tests.v3.helpers import authenticated_client
+from tests.v3.helpers import last_json
+from tests.v3.helpers import last_kwargs
+from tests.v3.helpers import last_payload
 
 pytestmark = pytest.mark.anyio
-
-
-class FakeResponse:
-    def __init__(self, payload: object) -> None:
-        self.payload = payload
-        self.status_code = 200
-        self.content = b"{}"
-        self.text = str(payload)
-
-    def json(self) -> object:
-        return self.payload
-
-
-class FakeSession:
-    def __init__(self, payload: object) -> None:
-        self.response = FakeResponse(payload)
-        self.calls: list[dict[str, object]] = []
-
-    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
-        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-        return self.response
-
-
-def authenticated_client(session: FakeSession) -> Client:
-    return Client(
-        api_key="key",
-        api_secret="secret",
-        base_url="https://example.test",
-        session=session,
-        nonce_factory=lambda: 123456,
-    )
-
-
-def last_kwargs(session: FakeSession) -> Mapping[str, object]:
-    return cast("Mapping[str, object]", session.calls[-1]["kwargs"])
-
-
-def last_payload(session: FakeSession) -> Mapping[str, object]:
-    headers = cast("Mapping[str, str]", last_kwargs(session)["headers"])
-    payload = base64.b64decode(headers["X-MAX-PAYLOAD"]).decode()
-    return cast("Mapping[str, object]", json.loads(payload))
 
 
 def loan_payload(**overrides: object) -> dict[str, object]:
@@ -143,7 +101,7 @@ async def test_create_m_wallet_loan_and_history_construct_authenticated_requests
     assert loan == MWalletLoan.model_validate(loan_payload())
     assert create_session.calls[-1]["method"] == "POST"
     assert create_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/loan"
-    assert last_kwargs(create_session)["json"] == {"nonce": 123456, "currency": "eth", "amount": "0.019"}
+    assert last_json(create_session) == {"nonce": 123456, "currency": "eth", "amount": "0.019"}
     assert last_payload(create_session)["path"] == "/api/v3/wallet/m/loan"
 
     list_session = FakeSession([loan_payload()])
@@ -170,7 +128,7 @@ async def test_m_wallet_transfer_create_and_history_construct_requests() -> None
     assert transfer == MWalletTransfer.model_validate(transfer_payload())
     assert create_session.calls[-1]["method"] == "POST"
     assert create_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/transfer"
-    assert last_kwargs(create_session)["json"] == {"nonce": 123456, "currency": "eth", "amount": "0.019", "side": "in"}
+    assert last_json(create_session) == {"nonce": 123456, "currency": "eth", "amount": "0.019", "side": "in"}
 
     list_session = FakeSession([transfer_payload()])
     transfers = await authenticated_client(list_session).m_wallet_transfers(currency="eth", side="in", limit=1)
@@ -186,7 +144,7 @@ async def test_m_wallet_repayment_create_and_history_construct_requests() -> Non
     assert repayment == MWalletRepayment.model_validate(repayment_payload())
     assert create_session.calls[-1]["method"] == "POST"
     assert create_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/m/repayment"
-    assert last_kwargs(create_session)["json"] == {"nonce": 123456, "currency": "eth", "amount": "0.15"}
+    assert last_json(create_session) == {"nonce": 123456, "currency": "eth", "amount": "0.15"}
 
     list_session = FakeSession([repayment_payload()])
     repayments = await authenticated_client(list_session).m_wallet_repayments("eth", order="asc", limit=1)

--- a/tests/v3/test_private.py
+++ b/tests/v3/test_private.py
@@ -1,74 +1,23 @@
 from __future__ import annotations
 
-import base64
-import json
-from collections.abc import Mapping
-from typing import cast
-
 import pytest
 
 from maicoin.v3 import Account
-from maicoin.v3 import Client
 from maicoin.v3 import Order
 from maicoin.v3 import OrderSide
 from maicoin.v3 import OrderState
 from maicoin.v3 import OrderType
 from maicoin.v3 import PrivateTrade
 from maicoin.v3 import UserInfo
+from tests.v3.helpers import FakeSession
+from tests.v3.helpers import PagedFakeSession
+from tests.v3.helpers import authenticated_client
+from tests.v3.helpers import call_kwargs
+from tests.v3.helpers import last_json
+from tests.v3.helpers import last_kwargs
+from tests.v3.helpers import last_payload
 
 pytestmark = pytest.mark.anyio
-
-
-class FakeResponse:
-    def __init__(self, payload: object) -> None:
-        self.payload = payload
-        self.status_code = 200
-        self.content = b"{}"
-        self.text = str(payload)
-
-    def json(self) -> object:
-        return self.payload
-
-
-class FakeSession:
-    def __init__(self, payload: object) -> None:
-        self.response = FakeResponse(payload)
-        self.calls: list[dict[str, object]] = []
-
-    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
-        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-        return self.response
-
-
-class PagedFakeSession:
-    def __init__(self, pages: list[object]) -> None:
-        self.pages = pages
-        self.calls: list[dict[str, object]] = []
-
-    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
-        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-        page = self.pages[len(self.calls) - 1]
-        return FakeResponse(page)
-
-
-def last_kwargs(session: FakeSession | PagedFakeSession) -> Mapping[str, object]:
-    return cast("Mapping[str, object]", session.calls[-1]["kwargs"])
-
-
-def last_payload(session: FakeSession) -> Mapping[str, object]:
-    headers = cast("Mapping[str, str]", last_kwargs(session)["headers"])
-    payload = base64.b64decode(headers["X-MAX-PAYLOAD"]).decode()
-    return cast("Mapping[str, object]", json.loads(payload))
-
-
-def authenticated_client(session: FakeSession | PagedFakeSession) -> Client:
-    return Client(
-        api_key="key",
-        api_secret="secret",
-        base_url="https://example.test",
-        session=session,
-        nonce_factory=lambda: 123456,
-    )
 
 
 def order_payload(**overrides: object) -> dict[str, object]:
@@ -204,14 +153,14 @@ async def test_iter_wallet_trades_advances_from_id_and_stops_at_max_items() -> N
     trades = [trade async for trade in client.iter_wallet_trades(market="ethtwd", from_id=0, page_limit=2, max_items=3)]
 
     assert [trade.id for trade in trades] == [1, 2, 3]
-    assert cast("Mapping[str, object]", session.calls[0]["kwargs"])["params"] == {
+    assert call_kwargs(session, 0)["params"] == {
         "nonce": 123456,
         "market": "ethtwd",
         "from_id": 0,
         "order": "asc",
         "limit": 2,
     }
-    assert cast("Mapping[str, object]", session.calls[1]["kwargs"])["params"] == {
+    assert call_kwargs(session, 1)["params"] == {
         "nonce": 123456,
         "market": "ethtwd",
         "from_id": 2,
@@ -232,13 +181,13 @@ async def test_iter_order_history_advances_from_id_until_short_page() -> None:
     orders = [order async for order in client.iter_order_history("ethtwd", from_id=0, page_limit=2)]
 
     assert [order.id for order in orders] == [1, 2, 3]
-    assert cast("Mapping[str, object]", session.calls[0]["kwargs"])["params"] == {
+    assert call_kwargs(session, 0)["params"] == {
         "nonce": 123456,
         "market": "ethtwd",
         "from_id": 0,
         "limit": 2,
     }
-    assert cast("Mapping[str, object]", session.calls[1]["kwargs"])["params"] == {
+    assert call_kwargs(session, 1)["params"] == {
         "nonce": 123456,
         "market": "ethtwd",
         "from_id": 2,
@@ -310,7 +259,7 @@ async def test_create_and_cancel_order_send_authenticated_json_body() -> None:
     assert created.id == 87
     assert create_session.calls[-1]["method"] == "POST"
     assert create_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/order"
-    assert last_kwargs(create_session)["json"] == {
+    assert last_json(create_session) == {
         "nonce": 123456,
         "market": "ethtwd",
         "side": "buy",
@@ -326,10 +275,10 @@ async def test_create_and_cancel_order_send_authenticated_json_body() -> None:
     assert cancelled_order.state == "cancel"
     assert cancel_session.calls[-1]["method"] == "DELETE"
     assert cancel_session.calls[-1]["url"] == "https://example.test/api/v3/order"
-    assert last_kwargs(cancel_session)["json"] == {"nonce": 123456, "id": 87}
+    assert last_json(cancel_session) == {"nonce": 123456, "id": 87}
 
     cancel_all_session = FakeSession([order_payload(state="cancel")])
     cancelled = await authenticated_client(cancel_all_session).cancel_orders(market="ethtwd", side="buy")
     assert cancelled[0].state == "cancel"
     assert cancel_all_session.calls[-1]["url"] == "https://example.test/api/v3/wallet/spot/orders"
-    assert last_kwargs(cancel_all_session)["json"] == {"nonce": 123456, "market": "ethtwd", "side": "buy"}
+    assert last_json(cancel_all_session) == {"nonce": 123456, "market": "ethtwd", "side": "buy"}

--- a/tests/v3/test_public.py
+++ b/tests/v3/test_public.py
@@ -1,44 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import cast
-
 import pytest
 
-from maicoin.v3 import Client
 from maicoin.v3 import Depth
 from maicoin.v3 import InterestRate
 from maicoin.v3 import KLine
 from maicoin.v3 import Market
 from maicoin.v3 import Ticker
+from tests.v3.helpers import FakeSession
+from tests.v3.helpers import last_params
+from tests.v3.helpers import public_client
 
 pytestmark = pytest.mark.anyio
-
-
-class FakeResponse:
-    def __init__(self, payload: object) -> None:
-        self.payload = payload
-        self.status_code = 200
-        self.content = b"{}"
-        self.text = str(payload)
-
-    def json(self) -> object:
-        return self.payload
-
-
-class FakeSession:
-    def __init__(self, payload: object) -> None:
-        self.response = FakeResponse(payload)
-        self.calls: list[dict[str, object]] = []
-
-    async def request(self, method: str, url: str, **kwargs: object) -> FakeResponse:
-        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-        return self.response
-
-
-def last_params(session: FakeSession) -> Mapping[str, object]:
-    kwargs = cast("Mapping[str, object]", session.calls[-1]["kwargs"])
-    return cast("Mapping[str, object]", kwargs["params"])
 
 
 async def test_markets_returns_market_models() -> None:
@@ -57,7 +30,7 @@ async def test_markets_returns_market_models() -> None:
             }
         ]
     )
-    client = Client(base_url="https://example.test", session=session)
+    client = public_client(session)
 
     markets = await client.markets()
 
@@ -107,7 +80,7 @@ async def test_currencies_returns_currency_models() -> None:
             }
         ]
     )
-    client = Client(base_url="https://example.test", session=session)
+    client = public_client(session)
 
     currencies = await client.currencies()
 
@@ -117,14 +90,14 @@ async def test_currencies_returns_currency_models() -> None:
 
 
 async def test_timestamp_returns_timestamp_model() -> None:
-    client = Client(base_url="https://example.test", session=FakeSession({"timestamp": 1678766175}))
+    client = public_client(FakeSession({"timestamp": 1678766175}))
 
     assert (await client.timestamp()).timestamp == 1678766175
 
 
 async def test_kline_constructs_params_and_parses_rows() -> None:
     session = FakeSession([[1678766100, "1", "2", "0.5", "1.5", "42"]])
-    client = Client(base_url="https://example.test", session=session)
+    client = public_client(session)
 
     klines = await client.kline("btctwd", limit=1, period=5, timestamp=1678766100)
 
@@ -142,7 +115,7 @@ async def test_depth_constructs_params_and_parses_depth() -> None:
             "bids": [["2520028.3", "0.11903796"]],
         }
     )
-    client = Client(base_url="https://example.test", session=session)
+    client = public_client(session)
 
     depth = await client.depth("btctwd", limit=1, sort_by_price=True)
 
@@ -170,7 +143,7 @@ async def test_trades_constructs_params_and_parses_trades() -> None:
             }
         ]
     )
-    client = Client(base_url="https://example.test", session=session)
+    client = public_client(session)
 
     trades = await client.trades("ethtwd", timestamp=1521726960357, limit=1)
 
@@ -196,7 +169,7 @@ async def test_tickers_uses_bracket_array_param_and_parses_tickers() -> None:
         "vol_in_quote": "2005000.0",
     }
     session = FakeSession([ticker_payload])
-    client = Client(base_url="https://example.test", session=session)
+    client = public_client(session)
 
     tickers = await client.tickers(["btctwd", "ethusdt"])
 
@@ -222,7 +195,7 @@ async def test_ticker_constructs_params_and_parses_ticker() -> None:
             "vol_in_quote": "2005000.0",
         }
     )
-    client = Client(base_url="https://example.test", session=session)
+    client = public_client(session)
 
     ticker = await client.ticker("btctwd")
 
@@ -231,20 +204,20 @@ async def test_ticker_constructs_params_and_parses_ticker() -> None:
 
 
 async def test_m_wallet_public_methods_parse_payloads() -> None:
-    assert await Client(session=FakeSession({"btcusdt": "79848.60666667"})).m_wallet_index_prices() == {
+    assert await public_client(FakeSession({"btcusdt": "79848.60666667"})).m_wallet_index_prices() == {
         "btcusdt": "79848.60666667"
     }
-    assert await Client(session=FakeSession({"btc": "10.67520286"})).m_wallet_limits() == {"btc": "10.67520286"}
+    assert await public_client(FakeSession({"btc": "10.67520286"})).m_wallet_limits() == {"btc": "10.67520286"}
 
-    rates = await Client(
-        session=FakeSession({"btc": {"hourly_interest_rate": "0.00000126", "next_hourly_interest_rate": "0.00000126"}})
+    rates = await public_client(
+        FakeSession({"btc": {"hourly_interest_rate": "0.00000126", "next_hourly_interest_rate": "0.00000126"}})
     ).m_wallet_interest_rates()
     assert rates == {"btc": InterestRate(hourly_interest_rate="0.00000126", next_hourly_interest_rate="0.00000126")}
 
 
 async def test_m_wallet_historical_index_prices_constructs_params_and_parses_prices() -> None:
     session = FakeSession([{"timestamp": "1644572610000", "price": "43497.56666666"}])
-    client = Client(base_url="https://example.test", session=session)
+    client = public_client(session)
 
     prices = await client.m_wallet_historical_index_prices("btcusdt", start_time=1644572610000, end_time=1644572670000)
 


### PR DESCRIPTION
## Summary
- Add a shared REST v3 test harness for fake responses/sessions, public and authenticated clients, request inspection, and auth payload decoding.
- Refactor REST v3 endpoint tests to use the shared helpers instead of repeating fake transport and auth setup.
- Mark the REST v3 test-harness architecture deepening follow-up as complete.

## Tests
- `just`
- `just docs-build`