### PR TITLE
refactor(ws): deepen stream lifecycle modules

### DIFF
--- a/.agents/docs/TODO.md
+++ b/.agents/docs/TODO.md
@@ -13,7 +13,7 @@ Plan: [`plans/codebase-architecture-deepening-opportunities.md`](plans/codebase-
 
 - [x] Deepen the REST v3 test harness so fake transport, authenticated clients, request inspection, and auth payload decoding live behind one test Module.
 - [x] Split REST v3 raw models by domain family while preserving public `maicoin.v3` and `maicoin.v3.models` imports.
-- [ ] Deepen the WebSocket Stream lifecycle implementation so reconnect/session and response dispatch rules have stronger locality.
+- [x] Deepen the WebSocket Stream lifecycle implementation so reconnect/session and response dispatch rules have stronger locality.
 - [ ] Add a public export / docs-reference consistency check to prevent strict MkDocs autorefs drift.
 - [ ] Consider deeper REST v3 endpoint declarations that combine request metadata with response shape once the current endpoint-family pattern settles.
 - [ ] Explore WebSocket Response event interpretation only after deciding the intended Interface for event-to-payload invariants.

--- a/src/maicoin/ws/_stream/__init__.py
+++ b/src/maicoin/ws/_stream/__init__.py
@@ -1,0 +1,25 @@
+from maicoin.ws._stream.dispatch import ResponseDispatcher
+from maicoin.ws._stream.reconnect import ReconnectLoop
+from maicoin.ws._stream.reconnect import ReconnectPolicy
+from maicoin.ws._stream.session import ConnectedSession
+from maicoin.ws._stream.types import ConnectFactory
+from maicoin.ws._stream.types import DispatchMode
+from maicoin.ws._stream.types import Handler
+from maicoin.ws._stream.types import HandlerErrorCallback
+from maicoin.ws._stream.types import LifecycleCallback
+from maicoin.ws._stream.types import WebSocketConnection
+from maicoin.ws._stream.types import WebSocketContext
+
+__all__ = [
+    "ConnectFactory",
+    "ConnectedSession",
+    "DispatchMode",
+    "Handler",
+    "HandlerErrorCallback",
+    "LifecycleCallback",
+    "ReconnectLoop",
+    "ReconnectPolicy",
+    "ResponseDispatcher",
+    "WebSocketConnection",
+    "WebSocketContext",
+]

--- a/src/maicoin/ws/_stream/dispatch.py
+++ b/src/maicoin/ws/_stream/dispatch.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+from maicoin.ws._stream.types import DispatchMode
+from maicoin.ws._stream.types import Handler
+from maicoin.ws._stream.types import HandlerErrorCallback
+from maicoin.ws.response import Response
+
+
+class ResponseDispatcher:
+    """Own response dispatch mode rules, handler errors, and task cleanup."""
+
+    def __init__(
+        self,
+        *,
+        dispatch: DispatchMode,
+        handlers: list[Handler],
+        response_queue: asyncio.Queue[Response],
+        on_handler_error: HandlerErrorCallback | None = None,
+    ) -> None:
+        if dispatch not in {"inline", "task", "queue"}:
+            msg = "dispatch must be 'inline', 'task', or 'queue'"
+            raise ValueError(msg)
+
+        self.dispatch = dispatch
+        self.handlers = handlers
+        self.response_queue = response_queue
+        self.on_handler_error = on_handler_error
+        self._handler_tasks: set[asyncio.Task[object]] = set()
+
+    async def dispatch_response(self, response: Response) -> None:
+        if self.dispatch == "queue":
+            await self.response_queue.put(response)
+            return
+
+        for handler in self.handlers:
+            if self.dispatch == "task":
+                task = asyncio.create_task(self.call_handler(handler, response))
+                self._handler_tasks.add(task)
+                task.add_done_callback(self._handler_tasks.discard)
+            else:
+                await self.call_handler(handler, response)
+
+    async def call_handler(self, handler: Handler, response: Response) -> None:
+        try:
+            result = handler(response)
+            if inspect.isawaitable(result):
+                await result
+        except Exception as exc:
+            if self.on_handler_error is None:
+                if self.dispatch == "inline":
+                    raise
+                return
+            result = self.on_handler_error(exc, response)
+            if inspect.isawaitable(result):
+                await result
+
+    async def cancel_handler_tasks(self) -> None:
+        for task in self._handler_tasks:
+            task.cancel()
+        if self._handler_tasks:
+            await asyncio.gather(*self._handler_tasks, return_exceptions=True)
+        self._handler_tasks.clear()

--- a/src/maicoin/ws/_stream/lifecycle.py
+++ b/src/maicoin/ws/_stream/lifecycle.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import inspect
+
+from maicoin.ws._stream.types import LifecycleCallback
+
+
+async def call_lifecycle(callback: LifecycleCallback | None, exc: Exception | None) -> None:
+    if callback is None:
+        return
+    result = callback(exc)
+    if inspect.isawaitable(result):
+        await result

--- a/src/maicoin/ws/_stream/reconnect.py
+++ b/src/maicoin/ws/_stream/reconnect.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from collections.abc import Awaitable
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from maicoin.ws._stream.lifecycle import call_lifecycle
+from maicoin.ws._stream.types import ConnectFactory
+from maicoin.ws._stream.types import LifecycleCallback
+from maicoin.ws._stream.types import WebSocketConnection
+
+Sleep = Callable[[float], Awaitable[object]]
+ConnectedRun = Callable[[WebSocketConnection], Awaitable[object]]
+
+
+@dataclass(frozen=True)
+class ReconnectPolicy:
+    """Reconnect/backoff configuration for [`Stream`][maicoin.ws.Stream].
+
+    Args:
+        enabled: Whether to reconnect after non-cancellation disconnects.
+        max_retries: Maximum reconnect attempts after the initial connection.
+            `None` retries forever.
+        base_delay: Initial backoff delay in seconds.
+        max_delay: Maximum backoff delay in seconds.
+        jitter: Random delay added to each backoff, in seconds.
+    """
+
+    enabled: bool = True
+    max_retries: int | None = None
+    base_delay: float = 1.0
+    max_delay: float = 30.0
+    jitter: float = 1.0
+
+    def delay(self, retry_number: int) -> float:
+        """Return the reconnect delay for a 1-based retry number."""
+        backoff = min(self.max_delay, self.base_delay * 2 ** max(0, retry_number - 1))
+        if self.jitter <= 0:
+            return backoff
+        return backoff + random.uniform(0, self.jitter)
+
+
+def should_reconnect(policy: ReconnectPolicy, retry_count: int) -> bool:
+    if not policy.enabled:
+        return False
+    return policy.max_retries is None or retry_count <= policy.max_retries
+
+
+class ReconnectLoop:
+    """Own reconnect retry state, lifecycle callback ordering, and backoff sleep."""
+
+    def __init__(
+        self,
+        *,
+        uri: str,
+        connect_factory: ConnectFactory,
+        connect_options: dict[str, object],
+        reconnect_policy: ReconnectPolicy,
+        run_connected: ConnectedRun,
+        on_disconnected: LifecycleCallback | None = None,
+        on_reconnecting: LifecycleCallback | None = None,
+        on_permanent_failure: LifecycleCallback | None = None,
+        sleep: Sleep = asyncio.sleep,
+    ) -> None:
+        self.uri = uri
+        self.connect_factory = connect_factory
+        self.connect_options = connect_options
+        self.reconnect_policy = reconnect_policy
+        self.run_connected = run_connected
+        self.on_disconnected = on_disconnected
+        self.on_reconnecting = on_reconnecting
+        self.on_permanent_failure = on_permanent_failure
+        self.sleep = sleep
+
+    async def run(self) -> None:
+        retry_count = 0
+        while True:
+            try:
+                async with self.connect_factory(self.uri, **self.connect_options) as ws:
+                    retry_count = 0
+                    await self.run_connected(ws)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                await call_lifecycle(self.on_disconnected, exc)
+                retry_count += 1
+                if not self.should_reconnect(retry_count):
+                    await call_lifecycle(self.on_permanent_failure, exc)
+                    raise
+                await call_lifecycle(self.on_reconnecting, exc)
+                delay = self.reconnect_policy.delay(retry_count)
+                if delay > 0:
+                    await self.sleep(delay)
+
+    def should_reconnect(self, retry_count: int) -> bool:
+        return should_reconnect(self.reconnect_policy, retry_count)

--- a/src/maicoin/ws/_stream/session.py
+++ b/src/maicoin/ws/_stream/session.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from maicoin.ws._stream.dispatch import ResponseDispatcher
+from maicoin.ws._stream.lifecycle import call_lifecycle
+from maicoin.ws._stream.types import LifecycleCallback
+from maicoin.ws._stream.types import WebSocketConnection
+from maicoin.ws.request import Request
+from maicoin.ws.response import Response
+
+
+class ConnectedSession:
+    """Run one connected websocket session: replay requests, receive, parse, dispatch."""
+
+    def __init__(
+        self,
+        *,
+        requests: list[Request],
+        dispatcher: ResponseDispatcher,
+        on_connected: LifecycleCallback | None = None,
+    ) -> None:
+        self.requests = requests
+        self.dispatcher = dispatcher
+        self.on_connected = on_connected
+
+    async def run(self, ws: WebSocketConnection) -> None:
+        for request in self.requests:
+            await ws.send(request.message())
+        await call_lifecycle(self.on_connected, None)
+
+        while True:
+            data = await ws.recv()
+            response = Response.model_validate_json(data)
+            await self.dispatcher.dispatch_response(response)

--- a/src/maicoin/ws/_stream/types.py
+++ b/src/maicoin/ws/_stream/types.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from collections.abc import Callable
+from typing import Literal
+from typing import Protocol
+
+from maicoin.ws.response import Response
+
+DispatchMode = Literal["inline", "task", "queue"]
+"""Response dispatch strategy used by [`Stream`][maicoin.ws.Stream]."""
+
+Handler = Callable[[Response], object | Awaitable[object]]
+LifecycleCallback = Callable[[Exception | None], object | Awaitable[object]]
+HandlerErrorCallback = Callable[[Exception, Response], object | Awaitable[object]]
+
+
+class WebSocketConnection(Protocol):
+    """Minimal async websocket connection protocol used by [`Stream`][maicoin.ws.Stream]."""
+
+    async def send(self, message: str) -> None: ...
+
+    async def recv(self) -> str | bytes: ...
+
+    async def close(self) -> None: ...
+
+
+class WebSocketContext(Protocol):
+    """Async context manager returned by websocket connect factories."""
+
+    async def __aenter__(self) -> WebSocketConnection: ...
+
+    async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None: ...
+
+
+ConnectFactory = Callable[..., WebSocketContext]

--- a/src/maicoin/ws/stream.py
+++ b/src/maicoin/ws/stream.py
@@ -9,79 +9,43 @@ transient disconnect.
 from __future__ import annotations
 
 import asyncio
-import inspect
 import os
-import random
-from collections.abc import Awaitable
-from collections.abc import Callable
-from dataclasses import dataclass
-from typing import Literal
-from typing import Protocol
 from typing import cast
 
 import websockets
 
+from maicoin.ws._stream.dispatch import ResponseDispatcher
+from maicoin.ws._stream.lifecycle import call_lifecycle
+from maicoin.ws._stream.reconnect import ReconnectLoop
+from maicoin.ws._stream.reconnect import ReconnectPolicy
+from maicoin.ws._stream.reconnect import should_reconnect
+from maicoin.ws._stream.session import ConnectedSession
+from maicoin.ws._stream.types import ConnectFactory
+from maicoin.ws._stream.types import DispatchMode
+from maicoin.ws._stream.types import Handler
+from maicoin.ws._stream.types import HandlerErrorCallback
+from maicoin.ws._stream.types import LifecycleCallback
+from maicoin.ws._stream.types import WebSocketConnection
+from maicoin.ws._stream.types import WebSocketContext
 from maicoin.ws.request import Request
 from maicoin.ws.response import Response
 from maicoin.ws.subscription import Subscription
 
+__all__ = [
+    "MAX_WS_URI",
+    "ConnectFactory",
+    "DispatchMode",
+    "Handler",
+    "HandlerErrorCallback",
+    "LifecycleCallback",
+    "ReconnectPolicy",
+    "Stream",
+    "WebSocketConnection",
+    "WebSocketContext",
+]
+
 MAX_WS_URI = os.getenv("MAX_WS_URI", "wss://max-stream.maicoin.com/ws")
 """WebSocket endpoint. Override with the `MAX_WS_URI` env var (e.g. for staging)."""
-
-DispatchMode = Literal["inline", "task", "queue"]
-"""Response dispatch strategy used by [`Stream`][maicoin.ws.Stream]."""
-
-Handler = Callable[[Response], object | Awaitable[object]]
-LifecycleCallback = Callable[[Exception | None], object | Awaitable[object]]
-HandlerErrorCallback = Callable[[Exception, Response], object | Awaitable[object]]
-
-
-class WebSocketConnection(Protocol):
-    """Minimal async websocket connection protocol used by [`Stream`][maicoin.ws.Stream]."""
-
-    async def send(self, message: str) -> None: ...
-
-    async def recv(self) -> str | bytes: ...
-
-    async def close(self) -> None: ...
-
-
-class WebSocketContext(Protocol):
-    """Async context manager returned by websocket connect factories."""
-
-    async def __aenter__(self) -> WebSocketConnection: ...
-
-    async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None: ...
-
-
-ConnectFactory = Callable[..., WebSocketContext]
-
-
-@dataclass(frozen=True)
-class ReconnectPolicy:
-    """Reconnect/backoff configuration for [`Stream`][maicoin.ws.Stream].
-
-    Args:
-        enabled: Whether to reconnect after non-cancellation disconnects.
-        max_retries: Maximum reconnect attempts after the initial connection.
-            `None` retries forever.
-        base_delay: Initial backoff delay in seconds.
-        max_delay: Maximum backoff delay in seconds.
-        jitter: Random delay added to each backoff, in seconds.
-    """
-
-    enabled: bool = True
-    max_retries: int | None = None
-    base_delay: float = 1.0
-    max_delay: float = 30.0
-    jitter: float = 1.0
-
-    def delay(self, retry_number: int) -> float:
-        """Return the reconnect delay for a 1-based retry number."""
-        backoff = min(self.max_delay, self.base_delay * 2 ** max(0, retry_number - 1))
-        if self.jitter <= 0:
-            return backoff
-        return backoff + random.uniform(0, self.jitter)
 
 
 class Stream:
@@ -144,10 +108,6 @@ class Stream:
             **connect_options: Extra options forwarded to `websockets.connect`,
                 such as `ping_interval`, `ping_timeout`, `close_timeout`, and `max_queue`.
         """
-        if dispatch not in {"inline", "task", "queue"}:
-            msg = "dispatch must be 'inline', 'task', or 'queue'"
-            raise ValueError(msg)
-
         self.requests = []
         self.handlers = []
         self.uri = uri
@@ -161,7 +121,13 @@ class Stream:
         self.on_reconnecting = on_reconnecting
         self.on_permanent_failure = on_permanent_failure
         self.on_handler_error = on_handler_error
-        self._handler_tasks: set[asyncio.Task[object]] = set()
+        self._dispatcher = ResponseDispatcher(
+            dispatch=dispatch,
+            handlers=self.handlers,
+            response_queue=self.response_queue,
+            on_handler_error=on_handler_error,
+        )
+        self._handler_tasks = self._dispatcher._handler_tasks
 
         self.auth(api_key, api_secret)
 
@@ -241,32 +207,26 @@ class Stream:
 
     async def arun(self) -> None:
         """Async entry point: connect, replay queued requests, and dispatch responses forever."""
-        retry_count = 0
-        while True:
-            try:
-                async with self.connect_factory(self.uri, **self.connect_options) as ws:
-                    retry_count = 0
-                    for req in self.requests:
-                        await ws.send(req.message())
-                    await self._call_lifecycle(self.on_connected, None)
-
-                    while True:
-                        data = await ws.recv()
-                        resp = Response.model_validate_json(data)
-                        await self._dispatch(resp)
-            except asyncio.CancelledError:
-                await self._cancel_handler_tasks()
-                raise
-            except Exception as exc:
-                await self._call_lifecycle(self.on_disconnected, exc)
-                retry_count += 1
-                if not self._should_reconnect(retry_count):
-                    await self._call_lifecycle(self.on_permanent_failure, exc)
-                    raise
-                await self._call_lifecycle(self.on_reconnecting, exc)
-                delay = self.reconnect_policy.delay(retry_count)
-                if delay > 0:
-                    await asyncio.sleep(delay)
+        session = ConnectedSession(
+            requests=self.requests,
+            dispatcher=self._dispatcher,
+            on_connected=self.on_connected,
+        )
+        loop = ReconnectLoop(
+            uri=self.uri,
+            connect_factory=self.connect_factory,
+            connect_options=self.connect_options,
+            reconnect_policy=self.reconnect_policy,
+            run_connected=session.run,
+            on_disconnected=self.on_disconnected,
+            on_reconnecting=self.on_reconnecting,
+            on_permanent_failure=self.on_permanent_failure,
+        )
+        try:
+            await loop.run()
+        except asyncio.CancelledError:
+            await self._cancel_handler_tasks()
+            raise
 
     def add_handler(self, handler: Handler) -> None:
         """Register a callback invoked with each [`Response`][maicoin.ws.Response].
@@ -279,48 +239,16 @@ class Stream:
         self.handlers.append(handler)
 
     def _should_reconnect(self, retry_count: int) -> bool:
-        policy = self.reconnect_policy
-        if not policy.enabled:
-            return False
-        return policy.max_retries is None or retry_count <= policy.max_retries
+        return should_reconnect(self.reconnect_policy, retry_count)
 
     async def _dispatch(self, resp: Response) -> None:
-        if self.dispatch == "queue":
-            await self.response_queue.put(resp)
-            return
-
-        for handler in self.handlers:
-            if self.dispatch == "task":
-                task = asyncio.create_task(self._call_handler(handler, resp))
-                self._handler_tasks.add(task)
-                task.add_done_callback(self._handler_tasks.discard)
-            else:
-                await self._call_handler(handler, resp)
+        await self._dispatcher.dispatch_response(resp)
 
     async def _call_handler(self, handler: Handler, resp: Response) -> None:
-        try:
-            result = handler(resp)
-            if inspect.isawaitable(result):
-                await result
-        except Exception as exc:
-            if self.on_handler_error is None:
-                if self.dispatch == "inline":
-                    raise
-                return
-            result = self.on_handler_error(exc, resp)
-            if inspect.isawaitable(result):
-                await result
+        await self._dispatcher.call_handler(handler, resp)
 
     async def _call_lifecycle(self, callback: LifecycleCallback | None, exc: Exception | None) -> None:
-        if callback is None:
-            return
-        result = callback(exc)
-        if inspect.isawaitable(result):
-            await result
+        await call_lifecycle(callback, exc)
 
     async def _cancel_handler_tasks(self) -> None:
-        for task in self._handler_tasks:
-            task.cancel()
-        if self._handler_tasks:
-            await asyncio.gather(*self._handler_tasks, return_exceptions=True)
-        self._handler_tasks.clear()
+        await self._dispatcher.cancel_handler_tasks()

--- a/tests/ws/test_stream_dispatch.py
+++ b/tests/ws/test_stream_dispatch.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from maicoin.ws import Response
+from maicoin.ws._stream.dispatch import ResponseDispatcher
+
+MESSAGE = '{"e":"subscribed","s":[{"channel":"trade","market":"btctwd"}],"i":"client1","T":123456789}'
+
+
+@pytest.fixture
+def response() -> Response:
+    return Response.model_validate_json(MESSAGE)
+
+
+@pytest.mark.anyio
+async def test_inline_dispatch_runs_handlers_in_registration_order(response: Response) -> None:
+    calls: list[str] = []
+
+    async def first(_response: Response) -> None:
+        calls.append("first")
+
+    def second(_response: Response) -> None:
+        calls.append("second")
+
+    dispatcher = ResponseDispatcher(
+        dispatch="inline",
+        handlers=[first, second],
+        response_queue=asyncio.Queue(),
+    )
+
+    await dispatcher.dispatch_response(response)
+
+    assert calls == ["first", "second"]
+
+
+@pytest.mark.anyio
+async def test_inline_dispatch_reports_handler_errors(response: Response) -> None:
+    errors: list[tuple[Exception, Response]] = []
+
+    def fail(_response: Response) -> None:
+        raise RuntimeError("boom")
+
+    dispatcher = ResponseDispatcher(
+        dispatch="inline",
+        handlers=[fail],
+        response_queue=asyncio.Queue(),
+        on_handler_error=lambda exc, errored_response: errors.append((exc, errored_response)),
+    )
+
+    await dispatcher.dispatch_response(response)
+
+    assert [(type(exc), errored_response.event) for exc, errored_response in errors] == [(RuntimeError, "subscribed")]
+
+
+@pytest.mark.anyio
+async def test_queue_dispatch_enqueues_response_without_calling_handlers(response: Response) -> None:
+    queue: asyncio.Queue[Response] = asyncio.Queue()
+
+    def fail(_response: Response) -> None:
+        raise AssertionError("queue dispatch should not call handlers")
+
+    dispatcher = ResponseDispatcher(
+        dispatch="queue",
+        handlers=[fail],
+        response_queue=queue,
+    )
+
+    await dispatcher.dispatch_response(response)
+
+    assert queue.get_nowait() is response
+
+
+@pytest.mark.anyio
+async def test_task_dispatch_cleans_up_cancelled_handler_tasks(response: Response) -> None:
+    started = asyncio.Event()
+
+    async def slow(_response: Response) -> None:
+        started.set()
+        await asyncio.sleep(60)
+
+    dispatcher = ResponseDispatcher(
+        dispatch="task",
+        handlers=[slow],
+        response_queue=asyncio.Queue(),
+    )
+
+    await dispatcher.dispatch_response(response)
+    await started.wait()
+    await dispatcher.cancel_handler_tasks()
+
+    assert dispatcher._handler_tasks == set()

--- a/tests/ws/test_stream_reconnect.py
+++ b/tests/ws/test_stream_reconnect.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from maicoin.ws._stream.reconnect import ReconnectLoop
+from maicoin.ws._stream.reconnect import ReconnectPolicy
+from maicoin.ws._stream.types import WebSocketConnection
+
+
+class FakeConnection:
+    async def send(self, message: str) -> None:
+        return None
+
+    async def recv(self) -> str:
+        raise asyncio.CancelledError
+
+    async def close(self) -> None:
+        return None
+
+
+class FakeContext:
+    def __init__(self, connection: FakeConnection) -> None:
+        self.connection = connection
+
+    async def __aenter__(self) -> WebSocketConnection:
+        return self.connection
+
+    async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        return None
+
+
+def connect_factory(*_args: object, **_kwargs: object) -> FakeContext:
+    return FakeContext(FakeConnection())
+
+
+@pytest.mark.anyio
+async def test_reconnect_loop_orders_callbacks_sleep_and_retry() -> None:
+    events: list[str] = []
+    failures: list[BaseException] = [ConnectionError("dropped"), asyncio.CancelledError()]
+
+    async def run_connected(_connection: WebSocketConnection) -> None:
+        events.append("run")
+        failure = failures.pop(0)
+        raise failure
+
+    async def sleep(delay: float) -> None:
+        events.append(f"sleep:{delay}")
+
+    loop = ReconnectLoop(
+        uri="wss://example.invalid/ws",
+        connect_factory=connect_factory,
+        connect_options={},
+        reconnect_policy=ReconnectPolicy(max_retries=1, base_delay=0.5, jitter=0),
+        run_connected=run_connected,
+        on_disconnected=lambda exc: events.append(f"disconnected:{exc}"),
+        on_reconnecting=lambda exc: events.append(f"reconnecting:{exc}"),
+        sleep=sleep,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await loop.run()
+
+    assert events == ["run", "disconnected:dropped", "reconnecting:dropped", "sleep:0.5", "run"]
+
+
+@pytest.mark.anyio
+async def test_reconnect_loop_calls_permanent_failure_without_retry_when_disabled() -> None:
+    events: list[str] = []
+
+    async def run_connected(_connection: WebSocketConnection) -> None:
+        events.append("run")
+        raise ConnectionError("closed")
+
+    async def sleep(_delay: float) -> None:
+        raise AssertionError("disabled reconnect should not sleep")
+
+    loop = ReconnectLoop(
+        uri="wss://example.invalid/ws",
+        connect_factory=connect_factory,
+        connect_options={},
+        reconnect_policy=ReconnectPolicy(enabled=False, base_delay=0, jitter=0),
+        run_connected=run_connected,
+        on_disconnected=lambda exc: events.append(f"disconnected:{exc}"),
+        on_reconnecting=lambda exc: events.append(f"reconnecting:{exc}"),
+        on_permanent_failure=lambda exc: events.append(f"permanent:{exc}"),
+        sleep=sleep,
+    )
+
+    with pytest.raises(ConnectionError):
+        await loop.run()
+
+    assert events == ["run", "disconnected:closed", "permanent:closed"]

--- a/tests/ws/test_stream_session.py
+++ b/tests/ws/test_stream_session.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from maicoin.ws import Channel
+from maicoin.ws import Response
+from maicoin.ws import Subscription
+from maicoin.ws._stream.dispatch import ResponseDispatcher
+from maicoin.ws._stream.session import ConnectedSession
+from maicoin.ws.request import Request
+
+MESSAGE = '{"e":"subscribed","s":[{"channel":"trade","market":"btctwd"}],"i":"client1","T":123456789}'
+
+
+class FakeConnection:
+    def __init__(self, messages: list[str | BaseException]) -> None:
+        self.messages = messages
+        self.sent: list[str] = []
+
+    async def send(self, message: str) -> None:
+        self.sent.append(message)
+
+    async def recv(self) -> str:
+        item = self.messages.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.mark.anyio
+async def test_connected_session_replays_requests_then_parses_and_dispatches_responses() -> None:
+    queue: asyncio.Queue[Response] = asyncio.Queue()
+    events: list[str] = []
+    connection = FakeConnection([MESSAGE, asyncio.CancelledError()])
+    request = Request.subscribe([Subscription(channel=Channel.TRADE, market="btctwd")])
+    session = ConnectedSession(
+        requests=[request],
+        dispatcher=ResponseDispatcher(dispatch="queue", handlers=[], response_queue=queue),
+        on_connected=lambda _exc: events.append("connected"),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await session.run(connection)
+
+    response = queue.get_nowait()
+    assert connection.sent == [request.message()]
+    assert events == ["connected"]
+    assert response.event == "subscribed"


### PR DESCRIPTION
## Summary
- Keep the public `Stream` Interface stable while moving WebSocket lifecycle responsibilities into internal `_stream` Modules.
- Add locality for connected-session request replay/receive/parse flow, reconnect retry/callback/backoff flow, and response dispatch modes/task cleanup.
- Add focused tests for dispatch, reconnect lifecycle, and connected-session behavior, while preserving existing public `Stream` behavior tests.
- Mark the WebSocket Stream lifecycle architecture deepening item as complete.

## Tests
- `just`
- `just docs-build`