### PR TITLE
docs: add project memory notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,10 @@ Recent history uses short imperative or dependency-update messages, often from D
 ## Security & Configuration Tips
 
 Do not commit `.env` files, API keys, or secrets. Use `MAX_API_KEY` and `MAX_API_SECRET` only through local environment variables or ignored local configuration.
+
+## MEMORY.md
+
+- `MEMORY.md` is not auto-loaded. Check it before non-trivial debugging or design work when prior project context may matter.
+- Keep entries short and reusable.
+- `MEMORY.md` must use `## GOTCHA` and `## TASTE` sections.
+- After a non-trivial error or discovery, add one concise entry if it will help future work.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,10 @@
+# MEMORY.md
+
+## GOTCHA
+
+- REST v3 `Client` now delegates endpoint families to internal `src/maicoin/v3/_endpoints/` modules. Add or update `EndpointSpec` constants and `EndpointExecutor` calls in the relevant family module, while keeping public `Client` method signatures stable as thin delegators.
+- If REST v3 raw models are needed, add them to the matching `src/maicoin/v3/models/<domain>.py` module and re-export public names from `src/maicoin/v3/models/__init__.py` and `src/maicoin/v3/__init__.py` as needed.
+- REST v3 endpoint tests should use `tests.v3.helpers` (`FakeResponse`, `FakeSession`, `PagedFakeSession`, `public_client`, `authenticated_client`) and inspect requests with helpers like `last_kwargs`, `last_params`, `last_json`, `request_headers`, `auth_payload`, and `last_payload`.
+- WebSocket `Stream` lifecycle internals are split under `src/maicoin/ws/_stream/`; dispatch mode, handler error, and task cleanup changes belong in `src/maicoin/ws/_stream/dispatch.py`.
+
+## TASTE


### PR DESCRIPTION
## Summary
- add MEMORY.md with reusable project gotchas
- document when to consult and update MEMORY.md in AGENTS.md

## Tests
- not run (documentation-only change)
- pre-commit hooks from git commit passed for touched files