### PR TITLE
Support WebSocket private auth filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,18 @@ async with Client(api_key=..., api_secret=...) as client:
 ```python
 from maicoin.ws import Channel, Stream, Subscription
 
-stream = Stream()                  # or Stream.from_env() for private channels
+stream = Stream()
 stream.subscribe([Subscription(channel=Channel.TICKER, market="btcusdt")])
 stream.add_handler(lambda r: print(r.model_dump(exclude_none=True)))
 stream.run()
+```
+
+Private streams authenticate with optional filters for the private event families you want:
+
+```python
+from maicoin.ws import Filter, Stream
+
+stream = Stream.from_env(auth_filters=[Filter.ORDER, Filter.TRADE, Filter.ACCOUNT])
 ```
 
 Full runnable scripts: [`examples/rest.py`](examples/rest.py), [`examples/websocket.py`](examples/websocket.py).
@@ -106,7 +114,7 @@ RUN_LIVE_TESTS=1 uv run pytest -v -s -m live tests/live
 just live-test
 ```
 
-Private read-only live tests also require `MAX_API_KEY` and `MAX_API_SECRET`; `just` loads these from `.env` automatically. Set `MAX_LIVE_MARKET` to override the default public test market (`btctwd`). Destructive live tests are intentionally not implemented yet.
+Private read-only live tests also require `MAX_API_KEY` and `MAX_API_SECRET`; `just` loads these from `.env` automatically. Set `MAX_LIVE_MARKET` to override the default public test market (`btctwd`). Destructive live tests require a separate `RUN_DESTRUCTIVE_TESTS=1` gate and are intentionally not implemented without a reviewed safety plan.
 
 ## 📚 References
 

--- a/docs/plans/TODO.md
+++ b/docs/plans/TODO.md
@@ -12,35 +12,35 @@ Plan archived: [`archived/codebase-architecture-deepening-opportunities.md`](arc
 - [x] Split REST v3 raw models by domain family while preserving public `maicoin.v3` and `maicoin.v3.models` imports.
 - [x] Deepen the WebSocket Stream lifecycle implementation so reconnect/session and response dispatch rules have stronger locality.
 - [x] Add a public export / docs-reference consistency check to prevent strict MkDocs autorefs drift.
-- [ ] Consider deeper REST v3 endpoint declarations that combine request metadata with response shape once the current endpoint-family pattern settles.
-- [ ] Explore WebSocket Response event interpretation only after deciding the intended Interface for event-to-payload invariants.
+- [x] Consider deeper REST v3 endpoint declarations that combine request metadata with response shape once the current endpoint-family pattern settles. Decision recorded in [`archived/todo-follow-up-decisions.md`](archived/todo-follow-up-decisions.md).
+- [x] Explore WebSocket Response event interpretation only after deciding the intended Interface for event-to-payload invariants. Decision recorded in [`archived/todo-follow-up-decisions.md`](archived/todo-follow-up-decisions.md).
 
 ### Release / Package Polish
 
-- [ ] Fill in package metadata gaps, including the empty `description` in `pyproject.toml`.
-- [ ] Verify README, MkDocs docs, examples, and PyPI-facing metadata are consistent before the next release.
-- [ ] Run the local release-readiness gates, including `just` and `just docs-build`.
+- [x] Fill in package metadata gaps, including the empty `description` in `pyproject.toml`.
+- [x] Verify README, MkDocs docs, examples, and PyPI-facing metadata are consistent before the next release.
+- [x] Run the local release-readiness gates, including `just` and `just docs-build`.
 
 ### Official API Drift Audit
 
-- [ ] Compare REST v3 client coverage, payload fields, and naming against the official MAX HTTP API v3 documentation.
-- [ ] Compare WebSocket channels, subscription payloads, response fields, and auth behavior against the official WebSocket documentation.
-- [ ] Record and prioritize any missing, changed, or deprecated API behavior before adding new features.
+- [x] Compare REST v3 client coverage, payload fields, and naming against the official MAX HTTP API v3 documentation.
+- [x] Compare WebSocket channels, subscription payloads, response fields, and auth behavior against the official WebSocket documentation.
+- [x] Record and prioritize any missing, changed, or deprecated API behavior before adding new features. Audit recorded in [`archived/api-drift-audit.md`](archived/api-drift-audit.md).
 
 ### Documentation / Examples Polish
 
-- [ ] Add practical examples for retry behavior, pagination helpers, and async client lifecycle management.
-- [ ] Add richer WebSocket examples covering reconnect behavior, handler dispatch, and private stream setup.
-- [ ] Clarify safety guidance for private state-changing methods with explicit warnings and safe usage patterns.
+- [x] Add practical examples for retry behavior, pagination helpers, and async client lifecycle management.
+- [x] Add richer WebSocket examples covering reconnect behavior, handler dispatch, and private stream setup.
+- [x] Clarify safety guidance for private state-changing methods with explicit warnings and safe usage patterns.
 
 ### Destructive Live Tests
 
 Plan archived: [`archived/live-integration-tests-plan.md`](archived/live-integration-tests-plan.md). Read-only public and private live tests are implemented; destructive live tests remain intentionally out of scope until a separate safety design pass.
 
-- [ ] Design opt-in destructive live tests with explicit environment gates, balance checks, cleanup, and manual recovery steps.
+- [x] Design opt-in destructive live tests with explicit environment gates, balance checks, cleanup, and manual recovery steps. Design recorded in [`archived/destructive-live-test-safety.md`](archived/destructive-live-test-safety.md).
 
 ### Dataclass Low-Level Model Experiment
 
 Plan archived: [`archived/dataclass-low-level-models-plan.md`](archived/dataclass-low-level-models-plan.md).
 
-- [ ] Revisit low-level dataclass models only if fresh benchmark evidence shows value and there is a compatibility migration path.
+- [x] Revisit low-level dataclass models only if fresh benchmark evidence shows value and there is a compatibility migration path. Decision recorded in [`archived/todo-follow-up-decisions.md`](archived/todo-follow-up-decisions.md).

--- a/docs/plans/archived/api-drift-audit.md
+++ b/docs/plans/archived/api-drift-audit.md
@@ -1,0 +1,60 @@
+# MAX API drift audit
+
+Date: 2026-05-15 (Asia/Taipei)
+
+Sources:
+
+- REST v3 documentation: <https://max-api.maicoin.com/doc/v3.html>
+- REST v3 OpenAPI document: <https://max-api.maicoin.com/api/doc/external/v3>
+- WebSocket documentation: <https://maicoin.github.io/max-websocket-docs/>
+
+## Summary
+
+The REST v3 client route surface matches the official OpenAPI path surface as of this audit. The WebSocket models covered the current response events, but the outbound auth filter surface was missing the official `fast_trade_update` filter and the guide showed private events as nonexistent subscription channels.
+
+Both WebSocket issues were fixed in this pass.
+
+## REST v3 coverage
+
+The official REST OpenAPI document was compared against `EndpointSpec` declarations under `src/maicoin/v3/_endpoints/`.
+
+Covered route families:
+
+- Public market data: markets, currencies, timestamp, kline, depth, trades, ticker, tickers.
+- User and order history: info, accounts, wallet trades, open/closed/history orders, single order, order trades.
+- Order intake: create order, cancel order, bulk cancel.
+- Funds: withdrawals, withdrawal addresses, deposits, deposit address, internal transfers, rewards, fund transactions.
+- Convert: create convert, single convert, convert history.
+- M-Wallet: index prices, historical index prices, limits, interest rates, loans, transfers, repayments, liquidations, interests, ad ratio.
+
+No missing REST path was found. The `deposit_address` route from the official changelog is already represented by `DEPOSIT_ADDRESS`.
+
+Remaining REST watch points:
+
+- Keep raw dict return types for endpoints whose official shape is a currency/market keyed mapping until there is a stable typed model that improves readability.
+- If future endpoint-family modules start duplicating response parsing boilerplate, revisit endpoint declarations that combine route metadata with response shape.
+
+## WebSocket coverage
+
+The official WebSocket docs were compared against `Channel`, `Filter`, `Event`, `Response`, and the request/subscription tests.
+
+Covered public subscription channels:
+
+- `book`
+- `trade`
+- `ticker`
+- `kline`
+- `market_status`
+- `pool_quota`
+
+Covered private response events include order, trade, fast trade, account, M-Wallet order/trade/fast trade/account, ad ratio, and borrowing snapshots/updates.
+
+Drift found:
+
+| Priority | Area | Finding | Resolution |
+| --- | --- | --- | --- |
+| P0 | WebSocket auth filters | Official docs support `fast_trade_update`, but `Filter` did not. | Added `Filter.FAST_TRADE_UPDATE` and request serialization coverage. |
+| P1 | WebSocket private setup | Docs used nonexistent `Channel.ORDER`, `Channel.TRADE_UPDATE`, and `Channel.BALANCE_UPDATE`. Private events are selected by auth filters. | Updated docs/examples to use `Stream.from_env(auth_filters=[...])`. |
+| P1 | WebSocket ergonomics | `Request.auth()` could parse filters, but `Stream` could not request them directly. | Added `auth_filters` to `Stream`, `Stream.from_env()`, and `Stream.auth()`. |
+
+No remaining high-priority API drift is known after these fixes.

--- a/docs/plans/archived/destructive-live-test-safety.md
+++ b/docs/plans/archived/destructive-live-test-safety.md
@@ -1,0 +1,64 @@
+# Destructive live-test safety design
+
+Date: 2026-05-15 (Asia/Taipei)
+
+Destructive live tests are tests that can change real account state: order placement/cancellation, transfers, withdrawals, convert orders, M-Wallet borrow/repay/transfer, or any future endpoint with equivalent risk.
+
+## Opt-in gates
+
+Every destructive live test must:
+
+- Use both `@pytest.mark.live` and `@pytest.mark.destructive`.
+- Stay skipped unless `RUN_LIVE_TESTS=1` and `RUN_DESTRUCTIVE_TESTS=1` are both set.
+- Require `MAX_API_KEY` and `MAX_API_SECRET`.
+- Require test-specific safety variables instead of hard-coded markets or amounts.
+
+Suggested safety variables:
+
+```dotenv
+MAX_DESTRUCTIVE_MARKET=btctwd
+MAX_DESTRUCTIVE_BASE_CURRENCY=btc
+MAX_DESTRUCTIVE_QUOTE_CURRENCY=twd
+MAX_DESTRUCTIVE_MAX_NOTIONAL_TWD=100
+MAX_DESTRUCTIVE_CLIENT_OID_PREFIX=maicoin-live-test
+```
+
+## Balance and limit checks
+
+Before submitting a state-changing request, the test must:
+
+- Fetch accounts with the same client that will submit the request.
+- Verify available balance is enough for setup and cleanup.
+- Verify the intended notional amount is at or below the configured maximum.
+- Verify the market/currency is explicitly allowlisted by environment variable.
+- Skip, not fail, when balances or limits are insufficient.
+
+## Cleanup
+
+Each test must own a unique local identifier, such as a `client_oid` with `MAX_DESTRUCTIVE_CLIENT_OID_PREFIX`.
+
+Cleanup requirements:
+
+- Cancel any order created by the test by exact `client_oid` or order id.
+- Re-read state after cleanup and assert no matching open order remains.
+- Never call broad cancellation APIs without exact filters.
+- Keep cleanup in `try` / `finally` so it runs when assertions fail.
+
+Transfers, withdrawals, and borrow/repay tests need a separate cleanup design before implementation. Do not add them just because the marker gates exist.
+
+## Manual recovery
+
+Every destructive test file must include a short module docstring or comment with:
+
+- The endpoint under test.
+- The environment variables required to run it.
+- How to find created resources by `client_oid`, order id, or transfer/withdrawal id.
+- The manual cleanup action if automatic cleanup fails.
+
+## CI policy
+
+Do not run destructive live tests in default CI. A future manual `workflow_dispatch` job may expose them only when:
+
+- The job environment has protected secrets.
+- The workflow input names the target market/currency.
+- The workflow logs print the configured maximum notional amount before running tests.

--- a/docs/plans/archived/todo-follow-up-decisions.md
+++ b/docs/plans/archived/todo-follow-up-decisions.md
@@ -1,0 +1,37 @@
+# TODO follow-up decisions
+
+Date: 2026-05-15 (Asia/Taipei)
+
+This records the architecture and model experiments that were intentionally left as TODO items after earlier deepening work.
+
+## REST endpoint declarations
+
+Decision: do not deepen endpoint declarations now.
+
+The current split is readable: endpoint families own domain methods, `EndpointSpec` owns route/auth metadata, and tests use shared helpers for request inspection. Combining route metadata with response shape would add another abstraction without removing a current pain point.
+
+Revisit only when one of these conditions is true:
+
+- A new endpoint family repeats enough parse/wrap boilerplate that the pattern is error-prone.
+- A route audit needs machine-readable response-shape metadata.
+- Public docs generation needs endpoint declarations as structured input.
+
+## WebSocket event interpretation
+
+Decision: keep `Response` as the wire-level public model and avoid a second interpretation layer for now.
+
+The response model already exposes typed optional payload fields for documented events. A stricter event-to-payload invariant layer would be useful only if downstream code needs dispatch on normalized payload kinds instead of raw MAX events.
+
+If that need appears, add an internal interpretation module first. It should map `Event` to a small descriptor containing the expected payload field, snapshot/update kind, and whether the event is public, spot private, or M-Wallet private. Do not make that module public until it has real caller pressure.
+
+## Dataclass low-level model experiment
+
+Decision: keep Pydantic models.
+
+There is no fresh benchmark evidence showing that dataclass-based low-level models would improve this package enough to justify a migration. Pydantic also remains useful for alias handling, validation, and docs reference generation.
+
+Revisit only with:
+
+- A benchmark that covers parsing realistic REST and WebSocket payloads.
+- A compatibility plan for public model imports and attributes.
+- A clear migration path for generated docs and tests.

--- a/docs/site/content/live-tests.md
+++ b/docs/site/content/live-tests.md
@@ -14,16 +14,19 @@ just live-test
 
 - **Public** — read-only tests against `Client().timestamp()`, `markets()`, `currencies()`, `ticker(...)`, `depth(...)`, `trades(...)`, `kline(...)`. No credentials required.
 - **Private read-only** — `Client.info()`, `accounts()`, `open_orders()`, `closed_orders()`, `wallet_trades()`. Skipped automatically when `MAX_API_KEY` / `MAX_API_SECRET` are missing.
-- **Destructive** — placing/cancelling orders, transfers, withdrawals, borrow/repay. Intentionally **not implemented** in the first pass; will require a separate `RUN_DESTRUCTIVE_TESTS=1` opt-in and risk controls.
+- **Destructive** — placing/cancelling orders, transfers, withdrawals, borrow/repay. These tests must be marked with both `live` and `destructive`, require `RUN_LIVE_TESTS=1` plus `RUN_DESTRUCTIVE_TESTS=1`, and must follow the archived safety design before implementation.
 
 ## Environment variables
 
 ```dotenv
 RUN_LIVE_TESTS=1
+RUN_DESTRUCTIVE_TESTS=1  # only for reviewed destructive tests
 MAX_API_KEY=your_key
 MAX_API_SECRET=your_secret
 MAX_LIVE_MARKET=btctwd   # optional override of the default public test market
 ```
+
+Destructive tests need additional test-specific limits, such as an allowlisted market, a maximum notional amount, and enough available balance for setup and cleanup. Do not add a destructive test that can run from the normal `just` or `just test` path.
 
 ## What they assert
 
@@ -35,4 +38,4 @@ Live tests are written to be stable across market conditions:
 
 ## CI
 
-Live tests do **not** run in default CI. The archived plan ([live-integration-tests-plan](https://github.com/narumiruna/maicoin/blob/main/docs/plans/archived/live-integration-tests-plan.md)) sketches a future `workflow_dispatch`-triggered job that reads credentials from GitHub Secrets.
+Live tests do **not** run in default CI. The archived plan ([live-integration-tests-plan](https://github.com/narumiruna/maicoin/blob/main/docs/plans/archived/live-integration-tests-plan.md)) sketches a future `workflow_dispatch`-triggered job that reads credentials from GitHub Secrets. Destructive test controls are tracked separately in [destructive-live-test-safety](https://github.com/narumiruna/maicoin/blob/main/docs/plans/archived/destructive-live-test-safety.md).

--- a/docs/site/content/quickstart.md
+++ b/docs/site/content/quickstart.md
@@ -38,10 +38,12 @@ stream.add_handler(lambda r: print(r.model_dump(exclude_none=True)))
 stream.run()
 ```
 
-For private channels (orders, balances, M-Wallet events) construct the stream from your environment:
+For private events (orders, trades, balances, M-Wallet events), authenticate the stream from your environment and choose auth filters:
 
 ```python
-stream = Stream.from_env()  # reads MAX_API_KEY / MAX_API_SECRET
+from maicoin.ws import Filter, Stream
+
+stream = Stream.from_env(auth_filters=[Filter.ORDER, Filter.TRADE, Filter.ACCOUNT])
 ```
 
 ## Runnable examples

--- a/docs/site/content/rest.md
+++ b/docs/site/content/rest.md
@@ -23,6 +23,16 @@ ticker = client.ticker_sync("btctwd")
 
 `_sync` wrappers use `asyncio.run()`, so code already running in an event loop should call the async methods directly.
 
+When you cannot use `async with`, close the client explicitly:
+
+```python
+client = Client(api_key="...", api_secret="...")
+try:
+    accounts = await client.accounts()
+finally:
+    await client.aclose()
+```
+
 You can override the base URL, timeout, retry policy, or HTTP session if needed:
 
 ```python
@@ -40,6 +50,18 @@ client = Client(
 ```
 
 Retries are conservative by default: only idempotent methods (`GET`, `HEAD`, `OPTIONS`) retry transient `429`, `502`, `503`, and `504` responses or network/timeout failures. `Retry-After` is respected when present. State-changing methods such as order placement and withdrawals are not retried unless you explicitly opt in with `RetryPolicy(retry_non_idempotent=True)`.
+
+Keep non-idempotent retries off for trading and transfer flows unless your own idempotency plan can tolerate a repeated request:
+
+```python
+safe_public_client = Client(retry_policy=RetryPolicy(total_attempts=3))
+
+explicit_opt_in = Client(
+    api_key="...",
+    api_secret="...",
+    retry_policy=RetryPolicy(total_attempts=3, retry_non_idempotent=True),
+)
+```
 
 ## Public endpoints
 
@@ -64,8 +86,37 @@ await client.closed_orders(market="btctwd", limit=10)
 await client.wallet_trades(limit=10)
 ```
 
+## Pagination helpers
+
+Use async iterators for ID-cursor history endpoints instead of managing `from_id` manually:
+
+```python
+async with Client(api_key="...", api_secret="...") as client:
+    async for order in client.iter_order_history("btctwd", page_limit=100):
+        print(order.id, order.state)
+
+    async for trade in client.iter_wallet_trades(market="btctwd", page_limit=100):
+        print(trade.id, trade.price)
+```
+
 !!! warning "⚠️ Private methods can move money"
     Private methods include order placement, withdrawals, internal transfers, convert orders, and M-Wallet borrow/repay/transfer. Double-check arguments before calling state-changing methods against a live account.
+
+For state-changing methods, prefer explicit identifiers and small scoped calls:
+
+```python
+await client.create_order(
+    market="btctwd",
+    side="buy",
+    volume="0.001",
+    price="1000",
+    ord_type="limit",
+    client_oid="local-dedupe-id",
+)
+
+# Avoid broad cancellation in automation. Cancel the exact order you created.
+await client.cancel_order(client_oid="local-dedupe-id")
+```
 
 ## Raw escape hatch
 

--- a/docs/site/content/websocket.md
+++ b/docs/site/content/websocket.md
@@ -23,23 +23,26 @@ stream.run()
 
 ## Private channels
 
-Private channels (user orders, balances, M-Wallet events) require credentials. Use [`Stream.from_env`][maicoin.ws.Stream.from_env] to construct the stream from `MAX_API_KEY` / `MAX_API_SECRET`:
+Private events (user orders, trades, balances, M-Wallet events) require credentials. Authenticate with optional [`Filter`][maicoin.ws.Filter] values to choose the event families MAX should send:
 
 ```python
-stream = Stream.from_env()
-stream.subscribe(
-    [
-        Subscription(channel=Channel.ORDER),
-        Subscription(channel=Channel.TRADE_UPDATE),
-        Subscription(channel=Channel.BALANCE_UPDATE),
-    ]
-)
+from maicoin.ws import Filter, Stream
+
+stream = Stream.from_env(auth_filters=[Filter.ORDER, Filter.TRADE, Filter.ACCOUNT])
+stream.add_handler(lambda r: print(r.event, r.model_dump(exclude_none=True)))
+stream.run()
 ```
 
-Or pass them explicitly:
+Or pass credentials explicitly:
 
 ```python
-stream = Stream(api_key="...", api_secret="...")
+from maicoin.ws import Filter, Stream
+
+stream = Stream(
+    api_key="...",
+    api_secret="...",
+    auth_filters=[Filter.ORDER, Filter.FAST_TRADE_UPDATE],
+)
 ```
 
 ## Handlers and dispatch modes
@@ -61,7 +64,13 @@ stream.add_handler(on_response)
 - `queue`: put responses into `stream.response_queue` for consumer-managed processing; registered handlers are ignored.
 
 ```python
-stream = Stream(dispatch="task", on_handler_error=lambda exc, response: print(exc))
+from maicoin.ws import Filter, Stream
+
+stream = Stream.from_env(
+    auth_filters=[Filter.ORDER, Filter.TRADE],
+    dispatch="task",
+    on_handler_error=lambda exc, response: print(exc),
+)
 
 queue_stream = Stream(dispatch="queue")
 # elsewhere: response = await queue_stream.response_queue.get()
@@ -72,9 +81,10 @@ queue_stream = Stream(dispatch="queue")
 By default, `Stream` reconnects after transient disconnects and replays queued auth/subscription requests. Configure backoff with [`ReconnectPolicy`][maicoin.ws.ReconnectPolicy], or disable reconnects with `reconnect=False`:
 
 ```python
-from maicoin.ws import ReconnectPolicy
+from maicoin.ws import Filter, ReconnectPolicy, Stream
 
-stream = Stream(
+stream = Stream.from_env(
+    auth_filters=[Filter.ORDER, Filter.ACCOUNT],
     reconnect_policy=ReconnectPolicy(max_retries=10, base_delay=1, max_delay=30),
     ping_interval=20,
     ping_timeout=20,
@@ -91,8 +101,10 @@ Extra keyword arguments are forwarded to `websockets.connect`, including heartbe
 ```python
 import asyncio
 
+from maicoin.ws import Filter, Stream
+
 async def main():
-    stream = Stream.from_env()
+    stream = Stream.from_env(auth_filters=[Filter.ORDER])
     stream.subscribe([...])
     stream.add_handler(...)
     await stream.arun()

--- a/examples/rest.py
+++ b/examples/rest.py
@@ -32,6 +32,10 @@ async def private_examples(client: Client) -> None:
     print("[bold magenta]open orders btctwd[/bold magenta]")
     print(await client.open_orders(market="btctwd"))
 
+    print("[bold magenta]recent order history btctwd[/bold magenta]")
+    async for order in client.iter_order_history("btctwd", page_limit=10, max_items=3):
+        print({"id": order.id, "state": order.state, "market": order.market})
+
 
 async def main() -> None:
     load_dotenv(find_dotenv())

--- a/examples/websocket.py
+++ b/examples/websocket.py
@@ -1,8 +1,11 @@
+import os
+
 from dotenv import find_dotenv
 from dotenv import load_dotenv
 from rich import print
 
 from maicoin.ws import Channel
+from maicoin.ws import Filter
 from maicoin.ws import Response
 from maicoin.ws import Stream
 from maicoin.ws import Subscription
@@ -14,6 +17,8 @@ def print_response_details(response: Response) -> None:
 
 def main() -> None:
     load_dotenv(find_dotenv())
+    api_key = os.environ.get("MAX_API_KEY")
+    api_secret = os.environ.get("MAX_API_SECRET")
 
     subscriptions = [
         Subscription(channel=Channel.BOOK, market="btcusdt", depth=5),
@@ -23,7 +28,16 @@ def main() -> None:
         Subscription(channel=Channel.MARKET_STATUS),
     ]
 
-    stream = Stream.from_env()
+    if api_key and api_secret:
+        stream = Stream(
+            api_key=api_key,
+            api_secret=api_secret,
+            auth_filters=[Filter.ORDER, Filter.TRADE, Filter.ACCOUNT],
+        )
+    else:
+        stream = Stream()
+        print("[yellow]MAX_API_KEY / MAX_API_SECRET not set — using public WebSocket channels only[/yellow]")
+
     stream.subscribe(subscriptions)
     stream.add_handler(print_response_details)
     stream.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,31 @@
 [project]
 name            = "maicoin"
 version         = "0.7.0"
-description     = ""
+description     = "Typed async Python client for the MaiCoin MAX REST v3 and WebSocket APIs."
 readme          = "README.md"
 requires-python = ">=3.12"
 authors         = [{ name = "narumi", email = "toucans-cutouts0f@icloud.com" }]
+keywords        = ["api", "crypto", "exchange", "maicoin", "max", "websocket"]
+classifiers     = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "Typing :: Typed",
+]
 dependencies    = [
   "httpx>=0.28.1",
   "orjson>=3.11.9",
   "pydantic>=2.13.4",
   "websockets>=16.0",
 ]
+
+[project.urls]
+Documentation = "https://narumiruna.github.io/maicoin/"
+Homepage      = "https://github.com/narumiruna/maicoin"
+Issues        = "https://github.com/narumiruna/maicoin/issues"
+Repository    = "https://github.com/narumiruna/maicoin"
 
 [dependency-groups]
 dev  = [

--- a/src/maicoin/ws/request.py
+++ b/src/maicoin/ws/request.py
@@ -36,6 +36,7 @@ class Filter(StrEnum):
     TRADE = "trade"
     ACCOUNT = "account"
     TRADE_UPDATE = "trade_update"
+    FAST_TRADE_UPDATE = "fast_trade_update"
     MWALLET_ORDER = "mwallet_order"
     MWALLET_TRADE = "mwallet_trade"
     MWALLET_FAST_TRADE_UPDATE = "mwallet_fast_trade_update"
@@ -72,11 +73,12 @@ class Request(BaseModel):
     """Subscriptions for `unsub` requests. Note: MAX uses the singular key here."""
 
     @classmethod
-    def auth(cls, api_key: str, api_secret: str) -> Request:
+    def auth(cls, api_key: str, api_secret: str, *, filters: list[Filter] | None = None) -> Request:
         """Build an `auth` request signed with `api_secret`.
 
         The signature is `HMAC-SHA256(api_secret, str(nonce))` where `nonce`
-        is the current UTC time in milliseconds.
+        is the current UTC time in milliseconds. Pass `filters` to narrow
+        private event families instead of receiving MAX's default private set.
         """
         nonce = int(datetime.now(tz=UTC).timestamp() * 1000)
 
@@ -90,6 +92,7 @@ class Request(BaseModel):
             api_key=api_key,
             signature=signature,
             nonce=nonce,
+            filters=filters,
         )
 
     @classmethod

--- a/src/maicoin/ws/stream.py
+++ b/src/maicoin/ws/stream.py
@@ -27,6 +27,7 @@ from maicoin.ws._stream.types import HandlerErrorCallback
 from maicoin.ws._stream.types import LifecycleCallback
 from maicoin.ws._stream.types import WebSocketConnection
 from maicoin.ws._stream.types import WebSocketContext
+from maicoin.ws.request import Filter
 from maicoin.ws.request import Request
 from maicoin.ws.response import Response
 from maicoin.ws.subscription import Subscription
@@ -77,6 +78,7 @@ class Stream:
         uri: str = MAX_WS_URI,
         reconnect: bool = True,
         reconnect_policy: ReconnectPolicy | None = None,
+        auth_filters: list[Filter] | None = None,
         dispatch: DispatchMode = "inline",
         response_queue: asyncio.Queue[Response] | None = None,
         connect_factory: ConnectFactory | None = None,
@@ -96,6 +98,7 @@ class Stream:
             reconnect: Convenience switch for reconnects. Ignored when
                 `reconnect_policy` is provided.
             reconnect_policy: Backoff/retry settings.
+            auth_filters: Optional private event filters for the auth request.
             dispatch: Handler dispatch strategy: `inline`, `task`, or `queue`.
             response_queue: Queue used by `dispatch="queue"`. Created lazily
                 when omitted.
@@ -129,7 +132,7 @@ class Stream:
         )
         self._handler_tasks = self._dispatcher._handler_tasks
 
-        self.auth(api_key, api_secret)
+        self.auth(api_key, api_secret, filters=auth_filters)
 
     def subscribe(self, subscriptions: list[Subscription]) -> None:
         """Queue a `subscribe` request for the given list of subscriptions.
@@ -139,15 +142,22 @@ class Stream:
         """
         self.requests += [Request.subscribe(subscriptions)]
 
-    def auth(self, api_key: str | None, api_secret: str | None) -> None:
+    def auth(
+        self,
+        api_key: str | None,
+        api_secret: str | None,
+        *,
+        filters: list[Filter] | None = None,
+    ) -> None:
         """Queue an `auth` request when credentials are present.
 
         Called automatically by `__init__`; expose as a method so credentials
         can also be added after construction. Missing credentials are silently
-        ignored — public-only streams stay unauthenticated.
+        ignored — public-only streams stay unauthenticated. Pass `filters` to
+        narrow MAX private event families.
         """
         if api_key and api_secret:
-            self.requests += [Request.auth(api_key, api_secret)]
+            self.requests += [Request.auth(api_key, api_secret, filters=filters)]
 
     @classmethod
     def from_env(
@@ -156,6 +166,7 @@ class Stream:
         uri: str = MAX_WS_URI,
         reconnect: bool = True,
         reconnect_policy: ReconnectPolicy | None = None,
+        auth_filters: list[Filter] | None = None,
         dispatch: DispatchMode = "inline",
         response_queue: asyncio.Queue[Response] | None = None,
         connect_factory: ConnectFactory | None = None,
@@ -185,6 +196,7 @@ class Stream:
             uri=uri,
             reconnect=reconnect,
             reconnect_policy=reconnect_policy,
+            auth_filters=auth_filters,
             dispatch=dispatch,
             response_queue=response_queue,
             connect_factory=connect_factory,

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -8,13 +8,17 @@ from maicoin.v3 import Client
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    if os.environ.get("RUN_LIVE_TESTS") == "1":
-        return
-
+    live_enabled = os.environ.get("RUN_LIVE_TESTS") == "1"
+    destructive_enabled = os.environ.get("RUN_DESTRUCTIVE_TESTS") == "1"
     skip_live = pytest.mark.skip(reason="set RUN_LIVE_TESTS=1 to run live integration tests")
+    skip_destructive = pytest.mark.skip(
+        reason="set RUN_DESTRUCTIVE_TESTS=1 only after reviewing destructive live-test safety controls"
+    )
     for item in items:
-        if "live" in item.keywords:
+        if "live" in item.keywords and not live_enabled:
             item.add_marker(skip_live)
+        if "destructive" in item.keywords and not destructive_enabled:
+            item.add_marker(skip_destructive)
 
 
 @pytest.fixture(scope="session")

--- a/tests/ws/test_request.py
+++ b/tests/ws/test_request.py
@@ -64,10 +64,19 @@ def test_action_auth_filters() -> None:
         "nonce": 1591690054859,
         "signature": "....",
         "id": "client-id",
-        "filters": ["order", "trade"],  # ignore account update
+        "filters": ["order", "trade", "fast_trade_update"],  # ignore account update
     }
 
-    Request.model_validate(d)
+    request = Request.model_validate(d)
+
+    assert request.filters == [Filter.ORDER, Filter.TRADE, Filter.FAST_TRADE_UPDATE]
+
+
+def test_auth_message_can_request_private_filters() -> None:
+    request = Request.auth("key", "secret", filters=[Filter.ORDER, Filter.FAST_TRADE_UPDATE])
+    message = json.loads(request.message())
+
+    assert message["filters"] == ["order", "fast_trade_update"]
 
 
 def test_action_auth_mwallet_filters() -> None:

--- a/tests/ws/test_stream.py
+++ b/tests/ws/test_stream.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 import pytest
 
 from maicoin.ws import Channel
+from maicoin.ws import Filter
 from maicoin.ws import ReconnectPolicy
 from maicoin.ws import Response
 from maicoin.ws import Stream
@@ -150,3 +151,9 @@ def test_stream_forwards_websocket_connect_options() -> None:
         "args": ("wss://example.invalid/ws",),
         "kwargs": {"ping_interval": 10, "ping_timeout": 5, "close_timeout": 2, "max_queue": 16},
     }
+
+
+def test_stream_auth_can_request_private_filters() -> None:
+    stream = Stream(api_key="key", api_secret="secret", auth_filters=[Filter.ORDER, Filter.FAST_TRADE_UPDATE])
+
+    assert stream.requests[0].filters == [Filter.ORDER, Filter.FAST_TRADE_UPDATE]


### PR DESCRIPTION
## Summary
- add WebSocket auth-filter support for Stream / Request, including fast_trade_update
- complete the release-readiness TODO pass with API drift, destructive live-test safety, and deferred architecture decision records
- refresh package metadata, docs, and examples for private auth filters, retry behavior, pagination helpers, and live-test gates

## Verification
- just
- just docs-build
- uv build --no-sources
- uv run --no-project --with dist/maicoin-0.7.0-py3-none-any.whl python -c "from maicoin.ws import Filter, Stream; from maicoin.v3 import Client; print(Filter.FAST_TRADE_UPDATE.value, Stream.__name__, Client.__name__)"
- git diff --check