### PR TITLE
docs: update plans guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This repository is a Python package for the MaiCoin MAX API. Core package code l
 - `tests/` mirrors package areas, with current coverage focused on `tests/ws/` and `tests/v3/`.
 - `examples/` contains runnable scripts (`rest.py`, `websocket.py`) that load MAX credentials from `.env` and exercise the package locally.
 - `docs/site/` contains the MkDocs site: `docs/site/mkdocs.yml` is the config, `docs/site/content/` is the published source, and `docs/site/build/` is generated output.
-- `docs/plans/` is for coding-agent-authored working documents: keep unfinished implementation plans and `TODO.md` there, and put completed plans or notes in `docs/plans/archived/`.
+- `docs/plans/` is for coding-agent-authored working documents: keep active or unfinished implementation plans there, and put completed plans or durable notes in `docs/plans/archived/`.
 
 ## Build, Test, and Development Commands
 

--- a/docs/plans/archived/codebase-architecture-deepening-opportunities.md
+++ b/docs/plans/archived/codebase-architecture-deepening-opportunities.md
@@ -2,7 +2,7 @@
 
 Status: **archived after completing the actionable first pass**.
 
-Completion note: the REST v3 test harness, REST v3 model locality, WebSocket Stream lifecycle split, and public export/docs-reference consistency check are complete. Remaining speculative candidates stay in `docs/plans/TODO.md` until there is a concrete trigger.
+Completion note: the REST v3 test harness, REST v3 model locality, WebSocket Stream lifecycle split, and public export/docs-reference consistency check are complete. Remaining follow-up decisions are recorded in `docs/plans/archived/todo-follow-up-decisions.md`; active follow-up plans belong in `docs/plans/`.
 
 This plan captures architecture deepening candidates found during the May 2026 codebase review. It is intentionally a planning document: do not implement every item at once. Pick one candidate, sharpen the intended Module Interface, then make a focused change with tests.
 
@@ -236,7 +236,7 @@ Keep endpoint tests focused on domain payloads and expected public Client behavi
 
 ### Files
 
-- `docs/plans/TODO.md`
+- future active plans under `docs/plans/`
 - `docs/plans/archived/client-resilience-and-ergonomics-follow-ups.md`
 - `tests/live/*`
 - future destructive live-test files

--- a/docs/site/content/development.md
+++ b/docs/site/content/development.md
@@ -41,7 +41,7 @@ tests/
   live/      # live integration tests (skipped by default)
 docs/
   site/      # MkDocs config, source, and generated build output
-  plans/     # coding-agent plans, TODOs, and archived notes
+  plans/     # active coding-agent plans and archived notes
 examples/     # runnable scripts using the real API
 ```
 


### PR DESCRIPTION
## Summary
- update AGENTS.md so plans guidance no longer references deleted TODO.md
- update development docs and archived architecture plan to avoid dangling TODO.md references

## Verification
- commit hooks ran during git commit
- env UV_CACHE_DIR=/tmp/uv-cache just docs-build